### PR TITLE
Codesman site title logo fix

### DIFF
--- a/scratch-parent/framework-customizations/theme/helpers.php
+++ b/scratch-parent/framework-customizations/theme/helpers.php
@@ -330,7 +330,7 @@ if (!function_exists('fw_theme_get_title_logo')) {
      * Get the Site Logo or an Option Name if there is no Logo Image
      * Defaults to 'blogname' if no option_name is passed
      * @param $option_name string The option_name that you want to display if there is no Logo.
-     * @return null|mixed
+     * @return string|null Logo Image or Site Title
      */
     function fw_theme_get_title_logo($option_name = 'blogname') {
         global $wpdb;

--- a/scratch-parent/framework/helpers/general.php
+++ b/scratch-parent/framework/helpers/general.php
@@ -2,29 +2,6 @@
 /**
  * Util functions
  */
-/**
- * Get the Site Logo or the Site Title(blogname) if there is no Logo Image
- *
- * @return null|mixed
- */
-function fw_get_title_logo()
-{
-    global $wpdb;
-
-    $prefixed_table = $wpdb->prefix . 'options';
-    $query = "SELECT `option_value` FROM `$prefixed_table` WHERE option_id = 3";
-
-    if ( $logo = fw_get_db_settings_option( 'logo' ) )
-    {
-        return $logo;
-    }
-    elseif ( $title = $wpdb->get_results( $query, ARRAY_A ) )
-    {
-        return $title[ 0 ][ 'option_value' ];
-    };
-
-    return null;
-}
 
 /**
  * Recursively find a key's value in array


### PR DESCRIPTION
Hello moldcraft,

I refactored the fw_theme_get_title_logo() and removed the hardcode as well as added the ability to pass an option name if you don't want the blogname.  I also moved the logic for the favicon link out of the header.php file.  It seemed like theme/helpers.php was the right place... I also think that the logic around fw_ext_get_analytics() in the header should be moved out.  Perhaps I'll get to that tomorrow.

Really digging working with this framework.

Thanks again!

Tom
