### PR TITLE
Minor fix in the fw_current_url function

### DIFF
--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -785,10 +785,7 @@ function fw_current_url() {
 
 	$pageURL .= '://';
 
-	if ($_SERVER['SERVER_PORT'] != '80')
-		$pageURL .= $_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['REQUEST_URI'];
-	else
-		$pageURL .= $_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];
+	$pageURL .= $_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
 
 	$cache = $pageURL;
 


### PR DESCRIPTION
I have modified the `fw_current_url` function to solve the problem in #126. I was able to reproduce the problem where the function returns an underscore instead of the correct server name. I am using nginx as well and using an underscore for the server name is quite common. Using `$_SERVER['HTTP_HOST']` instead returns both the correct server name and the port number.
