### PR TITLE
Extension options accept variables like Theme options.

### DIFF
--- a/framework/core/extends/class-fw-extension.php
+++ b/framework/core/extends/class-fw-extension.php
@@ -319,9 +319,10 @@ abstract class FW_Extension
 	/**
 	 * Return array with options from specified name/path
 	 * @param string $name Examples: 'framework', 'posts/portfolio'
+	 * @param array $variables These will be available in options file (like variables for view)
 	 * @return array
 	 */
-	final public function get_options($name)
+	final public function get_options($name, array $variables = array())
 	{
 		$path = $this->locate_path('/options/'. $name .'.php');
 
@@ -329,7 +330,7 @@ abstract class FW_Extension
 			return array();
 		}
 
-		$variables = fw_get_variables_from_file($path, array('options' => array()));
+		$variables = fw_get_variables_from_file($path, array('options' => array()), $variables);
 
 		return $variables['options'];
 	}


### PR DESCRIPTION
Copied get_options() from [_FW_Component_Theme](https://github.com/ThemeFuse/Unyson/blob/master/framework/core/components/theme.php#L66)  `fw()->theme->get_options( $name, $variables )`

Example:

    $ext = fw()->extensions->get( 'EXT_NAME' );
    $opt = $ext->get_options( 'options' , $variables );