### PR TITLE
introduce .getValuesFromServer() for fw.OptionsModal

### DIFF
--- a/framework/static/js/fw.js
+++ b/framework/static/js/fw.js
@@ -920,14 +920,14 @@ fw.getQueryString = function(name) {
 })();
 
 /**
- * @param {String} [actualValues] A string containing correctly serialized
- *                                data that will be sent to the server.
- *                                Ex.: "parameter1=val1&par2=value"
+ * @param {String} [data] An object with two keys:
+ *                        options: Your array with option types
+ *                        data: a string that will contain correctly serialized data
+ *                              Ex.: "parameter1=val1&par2=value"
  *
  * @returns {Promise} jQuery promise you can use in order to get your values
  *
- *
- * modal.getValuesFromServer()
+ * modal.getValuesFromServer({options: your_options})
  *     .done(function (response, status, xhr) {
  *         console.log(response.data.values); // your values ready to be used
  *     })

--- a/framework/static/js/fw.js
+++ b/framework/static/js/fw.js
@@ -919,6 +919,49 @@ fw.getQueryString = function(name) {
 	});
 })();
 
+/**
+ * @param {String} [actualValues] A string containing correctly serialized
+ *                                data that will be sent to the server.
+ *                                Ex.: "parameter1=val1&par2=value"
+ *
+ * @returns {Promise} jQuery promise you can use in order to get your values
+ *
+ *
+ * modal.getValuesFromServer()
+ *     .done(function (response, status, xhr) {
+ *         console.log(response.data.values); // your values ready to be used
+ *     })
+ *     .fail(function (xhr, status, error) {
+ *         // handle errors
+ *         console.error(status + ': ' + error);
+ *     });
+ */
+fw.getValuesFromServer = function (data) {
+	var opts = _.extend({
+		options: [],
+		actualValues: ""
+	}, data);
+
+	if (opts.options.length === 0) { return {}; }
+
+	var dataToSend = [
+		'action=fw_backend_options_get_values',
+		'options='+ encodeURIComponent(JSON.stringify(opts.options)),
+		'name_prefix=fw_edit_options_modal'
+	];
+
+	if (opts.actualValues) {
+		dataToSend.push(opts.actualValues);
+	}
+
+	return jQuery.ajax({
+		url: ajaxurl,
+		type: 'POST',
+		data: dataToSend.join('&'),
+		dataType: 'json'
+	});
+};
+
 (function(){
 	var fwLoadingId = 'fw-options-modal',
 		htmlCache = {};
@@ -1153,22 +1196,10 @@ fw.getQueryString = function(name) {
 		 *     });
 		 */
 		getValuesFromServer: function (actualValues) {
-			var dataToSend = [
-				'action=fw_backend_options_get_values',
-				'options='+ encodeURIComponent(JSON.stringify(this.get('options'))),
-				'name_prefix=fw_edit_options_modal'
-			];
-
-			if (actualValues) {
-				dataToSend.push(actualValues);
-			}
-
-			return jQuery.ajax({
-				url: ajaxurl,
-				type: 'POST',
-				data: dataToSend.join('&'),
-				dataType: 'json'
-			});
+			return fw.getValuesFromServer({
+				options: this.get('options'),
+				actualValues: actualValues
+			})
 		},
 
 		getHtmlCacheId: function(values) {


### PR DESCRIPTION
Sometimes, in the user code, we have to to get default values for every option before the user open modal. This is required in case you want defaults from every option to take place.

That is how you get your default values:

```javascript
var modal = new fw.OptionsModal({
    title: 'Your all way awesome title',

    options: [
        {
            'test_1': {
                'type': 'text',
                'value': 'default value you want to get'
            }
        }
    ],

    values: null // you may want to pre-popullate your modal if you saved some
                 // values before that
});

modal.on('change:values', function (modal, values) {
    // handle values saving
});

modal.getValuesFromServer()
    .done(function (response, status, xhr) {
        // your values ready to be used
        //
        // actual value you'll get in this case:
        // {test_1: 'default value you want to get'}
        console.log(response.data.values);
    })
    .fail(function (xhr, status, error) {
        // handle errors
        console.error(status + ': ' + error);
    });
```

The actual thing happens in `getValuesFromServer()` method. In fact, I've refactored `onSubmit()` method of `ContentView` to use this same `getValuesFromServer()` method.