### PR TITLE
disable uploader for fw.Modal()

### DIFF
--- a/framework/static/js/fw.js
+++ b/framework/static/js/fw.js
@@ -703,7 +703,8 @@ fw.getQueryString = function(name) {
 
 			this.frame = new wp.media.view.MediaFrame({
 				state: 'main',
-				states: [ new ControllerMainState ]
+				states: [ new ControllerMainState ],
+				uploader: false
 			});
 
 			var modal = this;


### PR DESCRIPTION
`fw.Modal()` inherits it's functionality from `MediaFrame`. As you can see [here](https://develop.svn.wordpress.org/trunk/src/wp-includes/js/media/views/media-frame.js), `wp.media` enables uploader for every `MediaFrame`. This will add a [nasty](https://cloud.githubusercontent.com/assets/2979628/13383030/e1363f62-de8a-11e5-9621-c1eb765f4f56.png) popup when you'll have an element that uses [HTML5 Drag and Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API) inside your modal. This pull request will prevent this situation.

It might be in the future that someone will need this uploader functional, but that's very unlikely. This person will know how to extend `fw.Modal()` in order to accept `uploader: true` as an option.