### PR TITLE
Introduce persisted options for theme settings

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -134,6 +134,8 @@ final class _FW_Component_Backend {
 			));
 		}
 
+		do_action('fw_option_types_before_init');
+
 		$this->add_actions();
 		$this->add_filters();
 	}

--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -1301,36 +1301,22 @@ final class _FW_Component_Backend {
 			 *
 			 * Usage:
 			 *
-			 * add_filter('fw_settings_prevent_reset', 'add_persisted_option');
+			 * add_filter('fw_settings_form_reset:values', 'add_persisted_option');
 			 *
-			 * function add_persisted_option ($current_persisted_options) {
+			 * function add_persisted_option ($current_persisted, $old_values) {
 			 *
-			 *   // be kind and don't remove other options that are
-			 *   // around already
-			 *   $current_persisted_options[] = 'my/multi/key';
+			 *   $value_to_persist = fw_akg('my/multi/key', $old_values);
 			 *
-			 *   return $current_persisted_options;
+			 *   fw_aks('my/multi/key', $value_to_persist, $current_persisted);
+			 *
+			 *   return $current_persisted;
 			 * }
 			 */
-			$options_to_prevent = apply_filters(
-				'fw_settings_prevent_reset',
-				array()
+
+			fw_set_db_settings_option(
+				null,
+				apply_filters('fw_settings_form_reset:values', array(), $old_values)
 			);
-
-			$options_to_set = array();
-
-			foreach ($options_to_prevent as $god_option) {
-				$god_value = fw_akg(
-					$god_option,
-					$old_values
-				);
-
-				if ($god_value) {
-					fw_aks($god_option, $god_value, $options_to_set);
-				}
-			}
-
-			fw_set_db_settings_option( null, $options_to_set );
 
 			FW_Flash_Messages::add( $flash_id, __( 'The options were successfully reset', 'fw' ), 'success' );
 


### PR DESCRIPTION
Introduce a filter that will collect [multikeys](http://manual.unyson.io/en/latest/helpers/php.html#multikey) that resolve to options from Theme Settings that have to be persisted from reset to reset.

Example:

```php
add_filter('fw_settings_prevent_reset', 'add_persisted_option');

function add_persisted_option ($current_persisted_options) {

    // be kind and don't remove other options that are
    // around already
    $current_persisted_options[] = 'my/multi/key';

    return $current_persisted_options;
}
```