### PR TITLE
Introduce fw_option_types_before_init action

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -134,6 +134,13 @@ final class _FW_Component_Backend {
 			));
 		}
 
+		/**
+		 * Option types are about to activate.
+		 * You can add subclasses to FW_Option_Type by hooking
+		 * up to this action.
+		 */
+		do_action('fw_option_types_before_init');
+
 		$this->add_actions();
 		$this->add_filters();
 	}


### PR DESCRIPTION
Introduce `fw_option_types_before_init` action. It is similar to [`fw_extensions_before_init`](https://github.com/ThemeFuse/Unyson/blob/42079d2c7103a04dbcd71d3950901ffd8f50747c/framework/core/components/extensions.php#L577).