### PR TITLE
Add Ability for Custom Setting Post Type

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -2031,14 +2031,22 @@ final class _FW_Component_Backend {
 						require_once fw_get_framework_directory('/includes/customizer/class--fw-customizer-control-option-wrapper.php');
 					}
 
+					$setting_args = array(
+						'default' => fw()->backend->option_type($opt['option']['type'])->get_value_from_input($opt['option'], null),
+						'fw_option' => $opt['option'],
+					);
+
+					$setting_type = $opt['option']['post_type'];
+
+					if(isset($setting_type)){
+						$setting_args['type'] = $setting_type;
+					}
+
 					$wp_customize->add_setting(
 						new _FW_Customizer_Setting_Option(
 							$wp_customize,
 							$setting_id,
-							array(
-								'default' => fw()->backend->option_type($opt['option']['type'])->get_value_from_input($opt['option'], null),
-								'fw_option' => $opt['option'],
-							)
+							$setting_args
 						)
 					);
 


### PR DESCRIPTION
Adds the ability to update settings not handled by theme_mod or options. This is a default Word Press customizer feature that's missing from Unyson. 
This way a custom hook can be used when the switch in $WP_Customize_Setting->update() resolves to default and returns:
do_action( 'customize_update_' . $this->type, $value, $this );