### PR TITLE
added a filter to override loader URI

### DIFF
--- a/framework/bootstrap-helpers.php
+++ b/framework/bootstrap-helpers.php
@@ -127,4 +127,19 @@ function fw_get_framework_customizations_dir_rel_path($append = '') {
 
 		return $cache . $rel_path;
 	}
+
+	/**
+	 * URI of the loader image
+	 * @param string $rel_path
+	 * @return string
+	 */
+	function fw_get_loader_image($rel_path = '') {
+		static $cache = null;
+
+		if ($cache === null) {
+			$cache = apply_filters( 'fw_loader_image', fw_get_framework_directory_uri() . '/static/img/logo.svg' );
+		}
+
+		return $cache . $rel_path;
+	}
 }

--- a/framework/bootstrap-helpers.php
+++ b/framework/bootstrap-helpers.php
@@ -127,19 +127,4 @@ function fw_get_framework_customizations_dir_rel_path($append = '') {
 
 		return $cache . $rel_path;
 	}
-
-	/**
-	 * URI of the loader image
-	 * @param string $rel_path
-	 * @return string
-	 */
-	function fw_get_loader_image($rel_path = '') {
-		static $cache = null;
-
-		if ($cache === null) {
-			$cache = apply_filters( 'fw_loader_image', fw_get_framework_directory_uri() . '/static/img/logo.svg' );
-		}
-
-		return $cache . $rel_path;
-	}
 }

--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -351,7 +351,7 @@ final class _FW_Component_Backend {
 			wp_localize_script( 'fw', '_fw_localized', array(
 				'FW_URI'     => fw_get_framework_directory_uri(),
 				'SITE_URI'   => site_url(),
-				'LOADER_URI' => fw_get_loader_image(),
+				'LOADER_URI' => apply_filters( 'fw_loader_image', fw_get_framework_directory_uri() . '/static/img/logo.svg' )
 				'l10n'       => array(
 					'done'     => __( 'Done', 'fw' ),
 					'ah_sorry' => __( 'Ah, Sorry', 'fw' ),

--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -351,7 +351,7 @@ final class _FW_Component_Backend {
 			wp_localize_script( 'fw', '_fw_localized', array(
 				'FW_URI'     => fw_get_framework_directory_uri(),
 				'SITE_URI'   => site_url(),
-				'LOADER_URI' => apply_filters( 'fw_loader_image', fw_get_framework_directory_uri() . '/static/img/logo.svg' )
+				'LOADER_URI' => apply_filters( 'fw_loader_image', fw_get_framework_directory_uri() . '/static/img/logo.svg' ),
 				'l10n'       => array(
 					'done'     => __( 'Done', 'fw' ),
 					'ah_sorry' => __( 'Ah, Sorry', 'fw' ),

--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -349,9 +349,10 @@ final class _FW_Component_Backend {
 			);
 
 			wp_localize_script( 'fw', '_fw_localized', array(
-				'FW_URI'   => fw_get_framework_directory_uri(),
-				'SITE_URI' => site_url(),
-				'l10n'     => array(
+				'FW_URI'     => fw_get_framework_directory_uri(),
+				'SITE_URI'   => site_url(),
+				'LOADER_URI' => fw_get_loader_image(),
+				'l10n'       => array(
 					'done'     => __( 'Done', 'fw' ),
 					'ah_sorry' => __( 'Ah, Sorry', 'fw' ),
 					'save'     => __( 'Save', 'fw' ),

--- a/framework/static/js/fw.js
+++ b/framework/static/js/fw.js
@@ -17,12 +17,14 @@ fw.FW_URI = _fw_localized.FW_URI;
 
 fw.SITE_URI = _fw_localized.SITE_URI;
 
+fw.LOADER_URI = _fw_localized.LOADER_URI;
+
 /**
  * Useful images
  */
 fw.img = {
 	loadingSpinner: fw.SITE_URI +'/wp-admin/images/spinner.gif',
-	logoSvg: fw.FW_URI +'/static/img/logo.svg'
+	logoSvg: fw.LOADER_URI
 };
 
 /**


### PR DESCRIPTION
Fixes #1463 

Still, using the original image from the framework as a fallback.

I have added a new function for the loader image URI which follows the similar function `fw_get_framework_directory_uri`

To use custom image as loader - 

```
/**
 * override loader image of unyson framework
 */
function imedica_core_loader_uri() {
	return get_stylesheet_directory_uri() . '/assets/images/loader.png';
}

add_filter( 'fw_loader_image', 'imedica_core_loader_uri' );
```