### PR TITLE
add a way to add custom events to every popup option

### DIFF
--- a/framework/includes/option-types/popup/class-fw-option-type-popup.php
+++ b/framework/includes/option-types/popup/class-fw-option-type-popup.php
@@ -53,7 +53,8 @@ class FW_Option_Type_Popup extends FW_Option_Type {
 			'title'   => ( isset( $option['popup-title'] ) ) ? $option['popup-title'] : ( string ) $option['label'],
 			'options' => $this->transform_options( $option['popup-options'] ),
 			'button'  => $option['button'],
-			'size'    => $option['size']
+			'size'    => $option['size'],
+			'custom-events' => $option['custom-events']
 		) );
 
 		if ( ! empty( $data['value'] ) ) {
@@ -173,7 +174,13 @@ class FW_Option_Type_Popup extends FW_Option_Type {
 			/*
 			 * Array of default values for the popup options
 			 */
-			'value'         => array()
+			'value'         => array(),
+
+			'custom-events' => array(
+				'open' => false,
+				'close' => false,
+				'render' => false
+			)
 		);
 	}
 

--- a/framework/includes/option-types/popup/static/js/popup.js
+++ b/framework/includes/option-types/popup/static/js/popup.js
@@ -58,12 +58,33 @@
 			},
 			'open': function () {
 				$this.trigger('fw:option-type:popup:open');
+
+				if (data['custom-events']['open']) {
+					fwEvents.trigger(data['custom-events']['open'], {
+						element: $this,
+						modal: utils.modal
+					});
+				}
 			},
 			'close': function () {
 				$this.trigger('fw:option-type:popup:close');
+
+				if (data['custom-events']['close']) {
+					fwEvents.trigger(data['custom-events']['close'], {
+						element: $this,
+						modal: utils.modal
+					});
+				}
 			},
 			'render': function () {
 				$this.trigger('fw:option-type:popup:render');
+
+				if (data['custom-events']['render']) {
+					fwEvents.trigger(data['custom-events']['render'], {
+						element: $this,
+						modal: utils.modal
+					});
+				}
 			}
 		});
 	};

--- a/framework/includes/option-types/popup/static/js/popup.js
+++ b/framework/includes/option-types/popup/static/js/popup.js
@@ -60,7 +60,7 @@
 				$this.trigger('fw:option-type:popup:open');
 
 				if (data['custom-events']['open']) {
-					fwEvents.trigger(data['custom-events']['open'], {
+					fwEvents.trigger('fw:option-type:popup:custom:' + data['custom-events']['open'], {
 						element: $this,
 						modal: utils.modal
 					});
@@ -70,7 +70,7 @@
 				$this.trigger('fw:option-type:popup:close');
 
 				if (data['custom-events']['close']) {
-					fwEvents.trigger(data['custom-events']['close'], {
+					fwEvents.trigger('fw:option-type:popup:custom:' + data['custom-events']['close'], {
 						element: $this,
 						modal: utils.modal
 					});
@@ -80,7 +80,7 @@
 				$this.trigger('fw:option-type:popup:render');
 
 				if (data['custom-events']['render']) {
-					fwEvents.trigger(data['custom-events']['render'], {
+					fwEvents.trigger('fw:option-type:popup:custom:' + data['custom-events']['render'], {
 						element: $this,
 						modal: utils.modal
 					});


### PR DESCRIPTION
This pull request will add a way to attach custom named events for each of the popups.
There are three phases of an popup: `render`, `open`, `close`. In fact, there's also `change` phase, but I will add this one by request.

That's how you attach an event to a particular phase:

```php
'id' => array(
	'type'          => 'popup',
	'size'			=> 'large',
	'popup-title'   => __( 'Button', 'fw' ),
	'button'        => __( 'Styling', 'fw' ),
	'custom-events' => array(
		'render' => 'custom-event-on-render',
		'close' => 'custom-event-on-close',
		'open' => 'custom-event-on-open'
	),
	'popup-options' => array() // ...
)
```

Then listen to this event in your JavaScript:

```javascript
fwEvents.on('event-name', function (data) {
  // do things
  // you have data.modal and data.element
}
```