### PR TITLE
Sometimes $input_value comes directly as an array

### DIFF
--- a/framework/includes/option-types/upload/class-fw-option-type-upload.php
+++ b/framework/includes/option-types/upload/class-fw-option-type-upload.php
@@ -205,7 +205,11 @@ class FW_Option_Type_Upload extends FW_Option_Type
 		if (empty($input_value)) {
 			return $option['value'];
 		} else {
-			return $this->get_attachment_info($input_value);
+			if (is_array($input_value)) {
+				return $input_value;
+			} else {
+				return $this->get_attachment_info($input_value);
+			}
 		}
 	}
 

--- a/framework/includes/option-types/upload/class-fw-option-type-upload.php
+++ b/framework/includes/option-types/upload/class-fw-option-type-upload.php
@@ -205,6 +205,10 @@ class FW_Option_Type_Upload extends FW_Option_Type
 		if (empty($input_value)) {
 			return $option['value'];
 		} else {
+			// Sometimes we want to do direct 
+			// [fw_get_options_values_from_input](fw-get-options-values-from-input) 
+			// and we pass full attachment array in, with `attachment_id` and `url`. 
+			// It should accept and work correctly with this form of calling it.
 			if (is_array($input_value)) {
 				return $input_value;
 			} else {


### PR DESCRIPTION
No need to parse it in this case.