### PR TITLE
Refactor wp-editor

### DIFF
--- a/framework/includes/option-types/addable-box/static/js/scripts.js
+++ b/framework/includes/option-types/addable-box/static/js/scripts.js
@@ -250,7 +250,21 @@ jQuery(document).ready(function ($) {
 				}, 300);
 			}
 
+
 			$boxes.append($newBox);
+
+			/**
+			 * Re-render wp-editor from newBox
+			 */
+			if ($option.find('.fw-option-box').length > 1) {
+				fwWpEditorRefreshIds(
+					$option.find(
+						'.fw-option-box:first textarea.wp-editor-area'
+					).attr('id'),
+
+					$newBox
+				);
+			}
 
 			methods.initControls($newBox);
 

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -2,6 +2,8 @@
 	die( 'Forbidden' );
 }
 
+require_once dirname(__FILE__) . '/includes/class-fw-wp-editor-settings.php';
+
 class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 	// prevent useless calls of wp_enqueue_*()
 	private static $enqueued = false;
@@ -50,21 +52,8 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 	 * @internal
 	 */
 	protected function _render( $id, $option, $data ) {
-		$settings = $this->get_option_settings($id, $option, $data);
-
-		{
-			unset( $option['attr']['name'], $option['attr']['value'] );
-
-			$option['attr']['data-size'] = $option['size'];
-			$option['attr']['data-mode'] = in_array($option['editor_type'], array('html', 'tinymce'))
-				? $option['editor_type'] : false;
-		}
-
-		echo '<div '. fw_attr_to_html($option['attr']) .' >';
-
-		wp_editor( $settings['value'], $settings['id'], $settings['settings'] );
-
-		echo '</div>';
+		$editor_manager = new FW_WP_Editor_Manager($id, $option, $data);
+		echo $editor_manager->get_html();
 	}
 
 	/**
@@ -89,6 +78,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 					array(),
 					fw()->manifest->get_version()
 				);
+
 				wp_enqueue_style(
 					/**
 					 * https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L737
@@ -121,80 +111,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			self::$enqueued = true;
 		}
 
-		/**
-		 * Make editor settings available in javascript tinyMCEPreInit.qtInit[ {$settings['id']} ]
-		 */
-		{
-			$settings = $this->get_option_settings($id, $option, $data);
-
-			unset($settings['teeny']); // I don't know why, but it breaks the default post wp editor
-
-			ob_start();
-			wp_editor( $settings['value'], $settings['id'], $settings['settings'] );
-			ob_end_clean();
-		}
-
 		return true;
-	}
-
-	private function get_option_settings($id, $option, $data) {
-		{
-			$_option = $option;
-
-			ksort($_option); // keys must be in same order to obtain the same hash
-
-			/**
-			 * The same option on enqueue and on modal ajax render can have different "fixed" values
-			 * Remove the values that happen to be different
-			 */
-			unset($_option['attr'], $_option['value'], $_option['label'], $_option['desc']);
-
-			/**
-			 * This must be unique for option
-			 * it will be in editor html and in javascript tinyMCEPreInit.qtInit[ {$id} ]
-			 */
-			$id = self::$wp_editor_id_prefix . md5( $id .'|'. json_encode($_option) );
-
-			unset($_option);
-		}
-
-		{
-			$settings = array();
-
-			foreach ( // https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/class-wp-editor.php#L80-L94
-				array(
-					'wpautop',
-					'media_buttons',
-					'default_editor',
-					'drag_drop_upload',
-					'textarea_name',
-					'textarea_rows',
-					'tabindex',
-					'tabfocus_elements',
-					'editor_css',
-					'editor_class',
-					'teeny',
-					'dfw',
-					'_content_editor_dfw',
-					'tinymce',
-					'quicktags',
-				) as $key
-			) {
-				if (isset($option[$key])) {
-					$settings[$key] = $option[$key];
-				}
-			}
-
-			$settings['editor_height'] = (int) $option['editor_height'];
-			$settings['textarea_name'] = $option['attr']['name'];
-		}
-
-		return array(
-			'id' => $id,
-			'settings' => $settings,
-			// replace \u00a0 char to &nbsp;
-			'value' => str_replace( chr( 194 ) . chr( 160 ), '&nbsp;', (string) $data['value'] )
-		);
 	}
 
 	/**

--- a/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
+++ b/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * The code is crazy. You better leave.
+ */
+
+if (! defined('FW')) { die('Forbidden'); }
+
+class FW_WP_Editor_Manager {
+	private $id = null;
+	private $option = null;
+	private $data = null;
+
+	/**
+	 * https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-editor.php#L305
+	 * An _WP_Editors::editor_settings call mutates those fields I list below.
+	 *
+	 * I need them to be mocked and after the manipulations are done to be
+	 * safely restored. I don't to cause troubles to WordPress execution engine.
+
+	 * 1. self::$first_init set to array() in order to skip add_action(), then restore
+	 * 2. preserve self::$qt_settings value
+	 * 3. preserve self::$qt_buttons
+	 * 4. preserve self::$baseurl
+	 * 5. preserve self::$mce_locale
+	 * 6. preserve self::$first_init
+	 * 7. $set['teeny'] should be not set
+	 * 8. preserve self::$mce_settings
+	 */
+	private $fields_to_mock_in_wp_editors = array(
+		'first_init', 'qt_settings', 'qt_buttons', 'baseurl',
+		'mce_locale', 'first_init', 'mce_settings'
+	);
+	private $mock_data = null;
+	private $reflection_class = null;
+
+	public function __construct($id, $option, $data) {
+		$this->id = $id;
+		$this->option = $option;
+		$this->data = $data;
+
+		/**
+		 * Generate random editor_id that will be used.
+		 * Using a hash of combination of $option and $id is not enough. It
+		 * usually repeats itself on the page pretty often.
+		 */
+		$this->editor_id = fw_rand_md5();
+	}
+
+	public function get_html() {
+		ob_start();
+
+		/**
+		 * This call will write something in _WP_Editors::$qt_settings and
+		 * _WP_Editors::$mce_settings. Let's keep them there, we'll rewrite any
+		 * data we need on the client side anyway later.
+		 */
+		wp_editor(
+			$this->get_value_for_render(),
+			$this->editor_id,
+			$this->get_settings()
+		);
+
+		$editor_html = ob_get_contents();
+
+		ob_end_clean();
+
+		$option = $this->option;
+
+		{
+			unset( $option['attr']['name'], $option['attr']['value'] );
+
+			$preinit_data = $this->get_preinit_data_for_editor();
+
+			$option['attr']['data-fw-editor-id'] = $this->editor_id;
+			$option['attr']['data-fw-mce-settings'] = json_encode($preinit_data['mce_settings']);
+			$option['attr']['data-fw-qt-settings'] = json_encode($preinit_data['qt_settings']);
+
+			$option['attr']['data-size'] = $option['size'];
+			$option['attr']['data-mode'] = in_array($option['editor_type'], array('html', 'tinymce'))
+				? $option['editor_type'] : false;
+		}
+
+		return fw_html_tag(
+			'div',
+			$option['attr'],
+			$editor_html
+		);
+	}
+
+	public function get_value_for_render() {
+		return str_replace(
+			chr( 194 ) . chr( 160 ),
+			'&nbsp;',
+			(string) $this->data['value']
+		);
+	}
+
+	public function get_settings() {
+		$settings = array();
+
+		foreach ( // https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/class-wp-editor.php#L80-L94
+			array(
+				'wpautop',
+				'media_buttons',
+				'default_editor',
+				'drag_drop_upload',
+				'textarea_name',
+				'textarea_rows',
+				'tabindex',
+				'tabfocus_elements',
+				'editor_css',
+				'editor_class',
+				'teeny',
+				'dfw',
+				'_content_editor_dfw',
+				'tinymce',
+				'quicktags',
+			) as $key
+		) {
+			if (isset($this->option[$key])) {
+				$settings[$key] = $this->option[$key];
+			}
+		}
+
+		if (isset($settings['teeny'])) {
+			unset($settings['teeny']);
+		}
+
+		$settings['editor_height'] = (int) $this->option['editor_height'];
+		$settings['textarea_name'] = $this->option['attr']['name'];
+
+		return $settings;
+	}
+
+	public function get_set() {
+
+		$set = _WP_Editors::parse_settings(
+			$this->editor_id,
+			$this->get_settings()
+		);
+
+		if ( ! current_user_can( 'upload_files' ) ) {
+			$set['media_buttons'] = false;
+		}
+
+		return $set;
+	}
+
+	/**
+	 * We need to get
+	 * _WP_Editors::$qt_settings and _WP_Editors::$mce_settings, after calling
+	 * it's editor_settings method. And it needs to be done without any mutation
+	 * to the class state itself. I've tryied HARD to not leave any
+	 * fingerprints there.
+	 */
+	public function get_preinit_data_for_editor() {
+		$this->mock_wp_editors_class();
+
+		/**
+		 * We are safe to do any modifications to the _WP_Editors here.
+		 * Any mocked data will be restored after our manipulations.
+		 */
+
+		/**
+		 * Skip add_action()
+		 * https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-editor.php#L308
+		 */
+		$this->set_static_field(
+			'first_init',
+			array()
+		);
+
+		/**
+		 * Set:
+		 * _WP_Editors::$qt_settings: https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-editor.php#L345
+		 *
+		 * _WP_Editors::$mce_settings: https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-editor.php#L740
+		 *
+		 * Then get them back using reflection class
+		 */
+		_WP_Editors::editor_settings(
+			$this->editor_id,
+			$this->get_set()
+		);
+
+		$mce_settings = $this->get_static_field('mce_settings');
+		$qt_settings = $this->get_static_field('qt_settings');
+
+		$mce_settings = fw_akg(
+			$this->editor_id,
+			$mce_settings,
+			array()
+		);
+
+		/**
+		 * https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-editor.php#L522
+		 *
+		 * _WP_Editors outputs JavaScript notation object, we want a valid JSON.
+		 *
+		 * Replace this:
+		 * {a: 1}
+		 * to
+		 * {"a": 1}
+		 */
+		$mce_settings['formats'] = preg_replace(
+			"/(\w+)\:/",
+			'"$1":',
+			$mce_settings['formats']
+		);
+
+		$mce_settings['formats'] = json_decode($mce_settings['formats'], true);
+
+		$qt_settings = fw_akg(
+			$this->editor_id,
+			$qt_settings,
+			array()
+		);
+
+		$preinit_data = array(
+			'mce_settings' => $mce_settings,
+			'qt_settings' => $qt_settings
+		);
+
+		$this->restore_wp_editors_class();
+
+		return $preinit_data;
+	}
+
+	public function mock_wp_editors_class() {
+		$this->reflection_class = new ReflectionClass('_WP_Editors');
+		$this->mock_data = array();
+
+		array_map(
+			array($this, 'backup_static_field'),
+			$this->fields_to_mock_in_wp_editors
+		);
+	}
+
+	public function restore_wp_editors_class() {
+		array_map(
+			array($this, 'restore_static_field'),
+			$this->fields_to_mock_in_wp_editors
+		);
+
+		$this->reflection_class = null;
+		$this->mock_data = null;
+	}
+
+	public function backup_static_field($field) {
+		$this->mock_data[$field] = $this->get_static_field($field);
+	}
+
+	public function restore_static_field($field) {
+		$this->set_static_field($field, $this->mock_data[$field]);
+	}
+
+	public function set_static_field($field, $value) {
+		$property = $this->reflection_class->getProperty($field);
+		$property->setAccessible(true);
+		$property->setValue($value);
+	}
+
+	public function get_static_field($field) {
+		$property = $this->reflection_class->getProperty($field);
+		$property->setAccessible(true);
+		return $property->getValue();
+	}
+}
+

--- a/framework/includes/option-types/wp-editor/static/scripts.js
+++ b/framework/includes/option-types/wp-editor/static/scripts.js
@@ -3,7 +3,17 @@
 	var init = function () {
 		var $option = $(this),
 			$textarea = $option.find('.wp-editor-area:first'),
-			id = $textarea.attr('id');
+			id = $option.attr('data-fw-editor-id');
+
+		/**
+		 * Dynamically set tinyMCEPreInit.mceInit and tinyMCEPreInit.qtInit
+		 * based on the data-fw-mce-settings and data-fw-qt-settings
+		 */
+		var mceSettings = JSON.parse($option.attr('data-fw-mce-settings'));
+		var qtSettings = JSON.parse($option.attr('data-fw-qt-settings'));
+
+		tinyMCEPreInit.mceInit[ id ] = mceSettings;
+		tinyMCEPreInit.qtInit[ id ] = qtSettings;
 
 		/**
 		 * Set width

--- a/framework/includes/option-types/wp-editor/static/scripts.js
+++ b/framework/includes/option-types/wp-editor/static/scripts.js
@@ -109,3 +109,29 @@
 
 })(jQuery, fwEvents);
 
+/**
+ * Find all wp-editor option types from container
+ * and give them new IDs (random MD5).
+ *
+ * Copy their preinit data from currentId.
+ *
+ * The main callback we have below will take care about populating
+ * tinyMCEPreInit.mceInit and tinyMCEPreInit.qtInit for them.
+ */
+function fwWpEditorRefreshIds(currentId, container) {
+	_.map(
+		jQuery(container).find('.fw-option-type-wp-editor').toArray(),
+		refreshEditor
+	);
+
+	function refreshEditor (editor) {
+		var html = jQuery(editor).clone().wrap('<p>').parent().html();
+		console.log(currentId);
+
+		var regexp = new RegExp(currentId, 'g');
+		html = html.replace(regexp, fw.randomMD5());
+
+		jQuery(editor).replaceWith(html);
+	}
+}
+


### PR DESCRIPTION
Long story short, this pull request fixes lots of problems with wp-editor by hijacking WordPress runtime.

Fixes 

- https://github.com/ThemeFuse/Unyson/issues/1674
- https://github.com/ThemeFuse/Unyson/issues/1466#issuecomment-211336425 
- https://github.com/ThemeFuse/Unyson/issues/1604

Testing steps are in #1674. Please repport any strange behavior you notice as soon as possible.

_If you want more info, read further._

<hr>

This pull request consists of two parts:

1. Introducing new uniqueness mechanism for `wp-editor`. Each editor now has unique ID generated completely random, which is not dependent on any predictable data (like we had before with options's `$id`). If you really want to know how it's done, please read the [code](https://github.com/ThemeFuse/Unyson/blob/9d0718be69745bd8c869fd7c43d802c8793a342c/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php).

2. Introducing [`fwWpEditorRefreshIds`](https://github.com/ThemeFuse/Unyson/blob/10b326ff5dcfacb41b637f192eed92df36a798dc/framework/includes/option-types/wp-editor/static/scripts.js#L121) javascript helper that will accept a container, loop through it's `wp-editor` instances and replace IDs for them. [This](https://github.com/ThemeFuse/Unyson/blob/10b326ff5dcfacb41b637f192eed92df36a798dc/framework/includes/option-types/wp-editor/static/scripts.js#L8) will take care of populating some global variables for successful `tinymce` initialisation process.

<hr>

I will later try to discuss with WordPress guys in a separate ticket about the shit I've done in the first part, maybe they will propose a better way of achieving this.

<hr>

Next step will be to fix `editor_integration.js` (and maybe something more) in order to be able to include Unyson shortcodes from any `wp-editor` instance.