### PR TITLE
Added default Google Maps API Key

### DIFF
--- a/framework/includes/option-types/map/class-fw-option-type-map.php
+++ b/framework/includes/option-types/map/class-fw-option-type-map.php
@@ -31,7 +31,7 @@ class FW_Option_Type_Map extends FW_Option_Type {
 
 		wp_enqueue_script(
 			'google-maps-api-v3',
-			'https://maps.googleapis.com/maps/api/js?v=3.15&sensor=false&libraries=places&language=' . $this->language,
+			'https://maps.googleapis.com/maps/api/js?key=' . self::api_key() . '&v=3.23&libraries=places&language=' . $this->language,
 			array(),
 			'3.15',
 			true
@@ -101,6 +101,10 @@ class FW_Option_Type_Map extends FW_Option_Type {
 				)
 			)
 		);
+	}
+
+	public static function api_key() {
+		return apply_filters( 'fw_option_map_gmap_api_key', 'AIzaSyBdZhjRWhxpheVoiPSks6wdVsR5SuYkbEo' );
 	}
 }
 


### PR DESCRIPTION
Added the `api_key()` static method for the Map option type, also added a default API key to solve temporary the huge problem everyone have with google maps notification. I would really recommend that plugin author to change the default API key with their own. 

This is a temporary solution and would be grate to come with a real normal extension for Google Maps.

Additionally, updated Google Maps API version. 