### PR TITLE
make wp-editor configurable; allows to attach a custom list of shortcodes

### DIFF
--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -121,7 +121,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			fw()->manifest->get_version()
 		);
 
-		do_action('fw:option_type:wp-editor:editor_shortcodes_scripts');
+		do_action('fw:option-type:wp-editor:enqueue-scripts');
 	}
 
 	/**

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -5,9 +5,6 @@
 require_once dirname(__FILE__) . '/includes/class-fw-wp-editor-settings.php';
 
 class FW_Option_Type_Wp_Editor extends FW_Option_Type {
-	// prevent useless calls of wp_enqueue_*()
-	private static $enqueued = false;
-
 	public function get_type() {
 		return 'wp-editor';
 	}
@@ -76,58 +73,53 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 	 * {@inheritdoc}
 	 */
 	protected function _enqueue_static( $id, $option, $data ) {
-		if (!self::$enqueued) {
-			/**
-			 * The below styles usually are included directly in html when wp_editor() is called
-			 * but since we call it (below) wrapped in ob_start()...ob_end_clean() the html is not printed.
-			 * So included the styles manually.
-			 */
-			{
-				wp_enqueue_style(
-					/**
-					 * https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L731
-					 * without prefix it won't enqueue
-					 */
-					'fw-option-type-' . $this->get_type() .'-dashicons',
-					includes_url('css/dashicons.min.css'),
-					array(),
-					fw()->manifest->get_version()
-				);
-
-				wp_enqueue_style(
-					/**
-					 * https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L737
-					 * without prefix it won't enqueue
-					 */
-					'fw-option-type-' . $this->get_type() .'-editor-buttons',
-					includes_url('/css/editor.min.css'),
-					array('dashicons', 'fw-unycon'),
-					fw()->manifest->get_version()
-				);
-			}
-
-			$uri = fw_get_framework_directory_uri('/includes/option-types/' . $this->get_type() . '/static');
-
-			wp_enqueue_script(
-				'fw-option-type-' . $this->get_type(),
-				$uri . '/scripts.js',
-				array('jquery', 'fw-events', 'editor', 'fw'),
-				fw()->manifest->get_version(),
-				true
-			);
-
+		/**
+		 * The below styles usually are included directly in html when wp_editor() is called
+		 * but since we call it (below) wrapped in ob_start()...ob_end_clean() the html is not printed.
+		 * So included the styles manually.
+		 */
+		{
 			wp_enqueue_style(
-				'fw-option-type-' . $this->get_type(),
-				$uri . '/styles.css',
-				array('dashicons', 'editor-buttons'),
+				/**
+				* https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L731
+				* without prefix it won't enqueue
+				*/
+				'fw-option-type-' . $this->get_type() .'-dashicons',
+				includes_url('css/dashicons.min.css'),
+				array(),
 				fw()->manifest->get_version()
 			);
 
-			self::$enqueued = true;
-
+			wp_enqueue_style(
+				/**
+				* https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L737
+				* without prefix it won't enqueue
+				*/
+				'fw-option-type-' . $this->get_type() .'-editor-buttons',
+				includes_url('/css/editor.min.css'),
+				array('dashicons', 'fw-unycon'),
+				fw()->manifest->get_version()
+			);
 		}
 
-		return true;
+		$uri = fw_get_framework_directory_uri(
+			'/includes/option-types/' . $this->get_type() . '/static'
+		);
+
+		wp_enqueue_script(
+			'fw-option-type-' . $this->get_type(),
+			$uri . '/scripts.js',
+			array('jquery', 'fw-events', 'editor', 'fw'),
+			fw()->manifest->get_version(),
+			true
+		);
+
+		wp_enqueue_style(
+			'fw-option-type-' . $this->get_type(),
+			$uri . '/styles.css',
+			array('dashicons', 'editor-buttons'),
+			fw()->manifest->get_version()
+		);
 	}
 
 	/**

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -81,9 +81,9 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 		{
 			wp_enqueue_style(
 				/**
-				* https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L731
-				* without prefix it won't enqueue
-				*/
+				 * https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L731
+				 * without prefix it won't enqueue
+				 */
 				'fw-option-type-' . $this->get_type() .'-dashicons',
 				includes_url('css/dashicons.min.css'),
 				array(),
@@ -92,9 +92,9 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 
 			wp_enqueue_style(
 				/**
-				* https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L737
-				* without prefix it won't enqueue
-				*/
+				 * https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/script-loader.php#L737
+				 * without prefix it won't enqueue
+				 */
 				'fw-option-type-' . $this->get_type() .'-editor-buttons',
 				includes_url('/css/editor.min.css'),
 				array('dashicons', 'fw-unycon'),

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -22,12 +22,25 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			'editor_height' => 160,
 			'wpautop' => true,
 			'editor_type' => false, // tinymce, html
+			'shortcodes_list' => $this->get_default_shortcodes_list()
 
 			/**
 			 * Also available
 			 * https://github.com/WordPress/WordPress/blob/4.4.2/wp-includes/class-wp-editor.php#L80-L94
 			 */
 		);
+	}
+
+	protected function get_default_shortcodes_list() {
+		$editor_shortcodes = fw_ext('editor-shortcodes-v2');
+
+		if (! $editor_shortcodes) {
+			return array(
+					'button', 'map', 'icon', 'divider', 'notification'
+			);
+		}
+
+		return $editor_shortcodes->default_shortcodes_list();
 	}
 
 	protected function _init() {
@@ -88,7 +101,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 					 */
 					'fw-option-type-' . $this->get_type() .'-editor-buttons',
 					includes_url('/css/editor.min.css'),
-					array('dashicons'),
+					array('dashicons', 'fw-unycon'),
 					fw()->manifest->get_version()
 				);
 			}

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -120,6 +120,8 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			array('dashicons', 'editor-buttons'),
 			fw()->manifest->get_version()
 		);
+
+		do_action('fw:option_type:wp-editor:editor_shortcodes_scripts');
 	}
 
 	/**

--- a/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
+++ b/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
@@ -75,6 +75,9 @@ class FW_WP_Editor_Manager {
 			$option['attr']['data-fw-editor-id'] = $this->editor_id;
 			$option['attr']['data-fw-mce-settings'] = json_encode($preinit_data['mce_settings']);
 			$option['attr']['data-fw-qt-settings'] = json_encode($preinit_data['qt_settings']);
+			$option['attr']['data-fw-shortcodes-list'] = json_encode(
+				$option['shortcodes_list']
+			);
 
 			$option['attr']['data-size'] = $option['size'];
 			$option['attr']['data-mode'] = in_array($option['editor_type'], array('html', 'tinymce'))


### PR DESCRIPTION
This pull request do two things:

- [x] Make `wp-editor` configurable, in order for new [Editor Shortcodes V.2](https://github.com/Creative-Themes/Unyson-EditorShortcodesV2-Extension) to work correctly
- [x] Implement an [assets enqueueing action](https://github.com/ThemeFuse/Unyson-Shortcodes-Extension/pull/60#discussion_r69122459) for other components to use 

Keeping track of the [Editor Shortcodes Implementation](https://github.com/Creative-Themes/Unyson-EditorShortcodesV2-Extension/issues/1) here.