### PR TITLE
Introduce WP-Shortcodes extension publicly

### DIFF
--- a/framework/core/components/extensions/manager/available-extensions.php
+++ b/framework/core/components/extensions/manager/available-extensions.php
@@ -90,6 +90,21 @@ $extensions = array(
 			),
 		),
 	),
+	'wp-shortcodes' => array(
+		'display'     => true,
+		'parent'      => 'shortcodes',
+		'name'        => __( 'WordPress Shortcodes', 'fw' ),
+		'description' => __(
+			'Lets you insert Unyson shortcodes inside any wp-editor',
+			'fw'
+		),
+		'thumbnail'   => $thumbnails_uri . '/page-builder.jpg',
+		'download'    => array(
+			'github' => array(
+				'user_repo' => 'Creative-Themes/Unyson-WP-Shortcodes-Extension',
+			),
+		),
+	),
 	'shortcodes' => array(
 		'display'     => false,
 		'parent'      => null,

--- a/framework/core/components/extensions/manager/available-extensions.php
+++ b/framework/core/components/extensions/manager/available-extensions.php
@@ -101,7 +101,7 @@ $extensions = array(
 		'thumbnail'   => $thumbnails_uri . '/page-builder.jpg',
 		'download'    => array(
 			'github' => array(
-				'user_repo' => 'Creative-Themes/Unyson-WP-Shortcodes-Extension',
+				'user_repo' => 'ThemeFuse/Unyson-WP-Shortcodes-Extension',
 			),
 		),
 	),

--- a/framework/extensions/clone-all.bash
+++ b/framework/extensions/clone-all.bash
@@ -26,7 +26,7 @@ forms:Unyson-Forms-Extension
 mailer:Unyson-Mailer-Extension
 social:Unyson-Social-Extension
 translation:Unyson-Translation-Extension
-shortcodes/extensions/wp-shortcodes:Creative-Themes/Unyson-WP-Shortcodes-Extension
+shortcodes/extensions/wp-shortcodes:Unyson-WP-Shortcodes-Extension
 '
 
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # script dir

--- a/framework/extensions/clone-all.bash
+++ b/framework/extensions/clone-all.bash
@@ -26,6 +26,7 @@ forms:Unyson-Forms-Extension
 mailer:Unyson-Mailer-Extension
 social:Unyson-Social-Extension
 translation:Unyson-Translation-Extension
+shortcodes/extensions/wp-shortcodes:Creative-Themes/Unyson-WP-Shortcodes-Extension
 '
 
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # script dir
@@ -39,7 +40,12 @@ echo "$EXTENSIONS" | grep -v '^$' | while read line; do
     if [ -d "$DIR" ]; then
         echo "[Warning] $DIR already exists. Skipping."
     else
-        COMMAND="git clone git@github.com:${ACCOUNT}/${REP}.git $DIR"
+        if [[ $REP == *"/"* ]]
+        then
+            COMMAND="git clone git@github.com:${REP}.git $DIR"
+        else
+            COMMAND="git clone git@github.com:${ACCOUNT}/${REP}.git $DIR"
+        fi
         echo "$COMMAND"
         $COMMAND
     fi

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -29,7 +29,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 	}
 
 	protected function get_default_shortcodes_list() {
-		$editor_shortcodes = fw_ext('editor-shortcodes-v2');
+		$editor_shortcodes = fw_ext('wp-shortcodes');
 
 		if (! $editor_shortcodes) {
 			return array(

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -25,12 +25,12 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			 *
 			 * You have two possible values:
 			 *   - false:   You will not have a shortcodes button at all
-			 *   - default: the default values you provide in wp-shortcodes
+			 *   - true:    the default values you provide in wp-shortcodes
 			 *              extension filter will be used
 			 *
 			 *   - An array of shortcodes
 			 */
-			'shortcodes' => false // 'default', array('button', map')
+			'shortcodes' => false // true, array('button', map')
 
 			/**
 			 * Also available

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -19,6 +19,17 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			'editor_height' => 160,
 			'wpautop' => true,
 			'editor_type' => false, // tinymce, html
+
+			/**
+			 * By default, you don't have any shortcodes into the editor.
+			 *
+			 * You have two possible values:
+			 *   - false:   You will not have a shortcodes button at all
+			 *   - default: the default values you provide in wp-shortcodes
+			 *              extension filter will be used
+			 *
+			 *   - An array of shortcodes
+			 */
 			'shortcodes_list' => false // 'default', array('button', map')
 
 			/**

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -30,7 +30,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			 *
 			 *   - An array of shortcodes
 			 */
-			'shortcodes_list' => false // 'default', array('button', map')
+			'shortcodes' => false // 'default', array('button', map')
 
 			/**
 			 * Also available
@@ -75,8 +75,8 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 	 * @internal
 	 */
 	protected function _render( $id, $option, $data ) {
-		if ($option['shortcodes_list'] === 'default') {
-			$option['shortcodes_list'] = $this->get_default_shortcodes_list();
+		if ($option['shortcodes']) {
+			$option['shortcodes'] = $this->get_default_shortcodes_list();
 		}
 
 		$editor_manager = new FW_WP_Editor_Manager($id, $option, $data);

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -19,7 +19,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 			'editor_height' => 160,
 			'wpautop' => true,
 			'editor_type' => false, // tinymce, html
-			'shortcodes_list' => $this->get_default_shortcodes_list()
+			'shortcodes_list' => false // 'default', array('button', map')
 
 			/**
 			 * Also available
@@ -64,6 +64,10 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 	 * @internal
 	 */
 	protected function _render( $id, $option, $data ) {
+		if ($option['shortcodes_list'] === 'default') {
+			$option['shortcodes_list'] = $this->get_default_shortcodes_list();
+		}
+
 		$editor_manager = new FW_WP_Editor_Manager($id, $option, $data);
 		echo $editor_manager->get_html();
 	}

--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -75,7 +75,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 	 * @internal
 	 */
 	protected function _render( $id, $option, $data ) {
-		if ($option['shortcodes']) {
+		if ($option['shortcodes'] === true) {
 			$option['shortcodes'] = $this->get_default_shortcodes_list();
 		}
 

--- a/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
+++ b/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
@@ -75,9 +75,13 @@ class FW_WP_Editor_Manager {
 			$option['attr']['data-fw-editor-id'] = $this->editor_id;
 			$option['attr']['data-fw-mce-settings'] = json_encode($preinit_data['mce_settings']);
 			$option['attr']['data-fw-qt-settings'] = json_encode($preinit_data['qt_settings']);
-			$option['attr']['data-fw-shortcodes-list'] = json_encode(
-				$option['shortcodes_list']
-			);
+
+
+			if ($option['shortcodes_list']) {
+				$option['attr']['data-fw-shortcodes-list'] = json_encode(
+					$option['shortcodes_list']
+				);
+			}
 
 			$option['attr']['data-size'] = $option['size'];
 			$option['attr']['data-mode'] = in_array($option['editor_type'], array('html', 'tinymce'))

--- a/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
+++ b/framework/includes/option-types/wp-editor/includes/class-fw-wp-editor-settings.php
@@ -77,9 +77,9 @@ class FW_WP_Editor_Manager {
 			$option['attr']['data-fw-qt-settings'] = json_encode($preinit_data['qt_settings']);
 
 
-			if ($option['shortcodes_list']) {
+			if ($option['shortcodes']) {
 				$option['attr']['data-fw-shortcodes-list'] = json_encode(
-					$option['shortcodes_list']
+					$option['shortcodes']
 				);
 			}
 


### PR DESCRIPTION
This pull request prepares all the groundwork for the [`WP-Shortcodes`](https://github.com/Creative-Themes/Unyson-WP-Shortcodes-Extension) to work correctly. It also changes the way `wp-editor` renders it order to give correct output for the extension to consume.

The extension is not stable yet, we are still working on it.