### PR TITLE
icon-v2 can be added as multi-picker picker

### DIFF
--- a/framework/includes/option-types/icon-v2/class-fw-option-type-icon-v2.php
+++ b/framework/includes/option-types/icon-v2/class-fw-option-type-icon-v2.php
@@ -97,6 +97,20 @@ class FW_Option_Type_Icon_v2 extends FW_Option_Type
 
 	protected function _get_value_from_input($option, $input_value)
 	{
+		/**
+		 * Handle the case when it is used as a multi-picker picker.
+		 * Return the current type in this case. Whether icon-type or custom-upload.
+		 */
+		if (isset($option['fw_multi_picker'])) {
+			$source = $input_value;
+
+			if (is_null($input_value)) {
+				$source = $option['value'];
+			}
+
+			return fw_akg('type', $source, 'icon-font');
+		}
+
 		if (is_null( $input_value )) {
 			return $option['value'];
 		}
@@ -107,7 +121,15 @@ class FW_Option_Type_Icon_v2 extends FW_Option_Type
 
 	protected function _get_db_value_from_json($input_value)
 	{
-		$input = json_decode($input_value, true);
+		$input = $input_value;
+
+		/**
+		 * When icon-v2 is used as a multi-picker picker it, the value
+		 * comes straight as array, you should parse it.
+		 */
+		if (! is_array($input_value)) {
+			$input = json_decode($input_value, true);
+		}
 
 		$result = array();
 

--- a/framework/includes/option-types/icon-v2/static/js/icon-picker.js
+++ b/framework/includes/option-types/icon-v2/static/js/icon-picker.js
@@ -426,7 +426,6 @@ window.fwOptionTypeIconV2Picker = (function ($) {
 	function computeModalHeight () {
 		var $icons = modal.frame.$el.find('.fw-icon-v2-library-packs-wrapper');
 		var toolbarHeight = modal.frame.$el.find('.fw-icon-v2-toolbar').height();
-		console.log('compute');
 
 		$icons.height(
 			modal.frame.$el.find(

--- a/framework/includes/option-types/icon-v2/static/js/render-icon-previews.js
+++ b/framework/includes/option-types/icon-v2/static/js/render-icon-previews.js
@@ -195,7 +195,7 @@
 					data
 				)
 			)
-		);
+		).trigger('change');
 
 		refreshSinglePreview($root);
 	}

--- a/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
+++ b/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
@@ -85,6 +85,21 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 				$picker_key   = key($option['picker']);
 				$picker_type  = $option['picker'][$picker_key]['type'];
 				$picker       = $option['picker'][$picker_key];
+
+				/**
+				 * A complex option type should be aware of the fact that currently
+				 * it's value is extracted from multi picker.
+				 * Multi picker accepts only a string as an output. Complex option
+				 * types often do more than this.
+				 *
+				 * The option type should return the correct choice branch
+				 * that should be selected when this key is present.
+				 *
+				 * TODO: This really should be documented somewhere else than
+				 * this dark place.
+				 */
+				$picker['fw_multi_picker'] = true;
+
 				$picker_value = fw()->backend->option_type($picker_type)->get_value_from_input(
 					$picker,
 					isset($data['value'][$picker_key]) ? $data['value'][$picker_key] : null
@@ -153,10 +168,21 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 					}
 				}
 				$picker_choices = array_intersect_key($option['choices'], $collected_choices);
+
 				break;
 			case 'radio':
 			case 'image-picker':
 				$picker_choices = array_intersect_key($option['choices'], $picker['choices']);
+				break;
+			case 'icon-v2':
+				$picker_choices = array_intersect_key(
+					$option['choices'],
+					array(
+						'icon-font' => array(),
+						'custom-upload' => array()
+					)
+				);
+
 				break;
 			default:
 				$picker_choices = apply_filters(

--- a/framework/includes/option-types/multi-picker/static/js/multi-picker.js
+++ b/framework/includes/option-types/multi-picker/static/js/multi-picker.js
@@ -61,6 +61,14 @@
 					elements.$pickerGroup.find('select').on('change', function() {
 						chooseGroup(this.value);
 					}).trigger('change');
+				},
+				'icon-v2': function () {
+					var iconV2Selector = '.fw-option-type-icon-v2 > input';
+
+					elements.$pickerGroup.find(iconV2Selector).on('change', function() {
+						var type = JSON.parse(this.value)['type'];
+						chooseGroup(type);
+					}).trigger('change');
 				}
 			};
 


### PR DESCRIPTION

Usage for `icon-v2` in `multi-picker`:

```php
'id' => array(
	'type' => 'multi-picker',
	'label' => false,
	'desc' => false,

	'picker' => array(
		'icon' => array(
			'label' => __('Choose', 'fw'),
			'type' => 'icon-v2'
		)
	),

	'choices' => array(
		/**
		 * Options for the case when an icon-font type is selected.
		 */
		'icon-font' => array(
			'text1' => array(
				'type' => 'text'
			)
		),

		/**
		 * Options for the case when an custom-upload type is selected.
		 */
		'custom-upload' => array(
			'text2' => array(
				'type' => 'text'
			)
		)
	)
),
```

The thing is that you cannot switch upon an icon specifically. The idea is that you switch options whether the user uses an `icon-font` or it used to upload a custom image out there. That's a more real world use case scenario.

_Maybe we'll add also the icon thing in the future, but I don't see a need for this, at least for now._

<hr>

Some notable news:

When you try to get the value of a picker with

```
fw()->backend->option_type($picker_type)->get_value_from_input()
```
you'll get also `fw_multi_picker` key in your `$option`. That's because each option type should know how to perform when they're used as a picker. This was really introduced in order to keep `icon-v2`s complex and dynamic structure as it is, without interfering with `multi-picker` interface.

You should really [read](https://github.com/andreiglingeanu/Unyson/blob/71298f9fa62cc8483f4f0eddf4dea15d8aa076fd/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php#L89) into this comment and check commit more carefully in order to understand the essence of the problem.