### PR TITLE
Fix variable name

### DIFF
--- a/framework/helpers/class-fw-wp-option.php
+++ b/framework/helpers/class-fw-wp-option.php
@@ -26,7 +26,7 @@ class FW_WP_Option
 		if (empty($specific_multi_key) && $specific_multi_key !== '0') {
 			return is_null($value) ? $default_value : $value;
 		} else {
-			return fw_akg($specific_multi_key, $values, $default_value);
+			return fw_akg($specific_multi_key, $value, $default_value);
 		}
 	}
 


### PR DESCRIPTION
This mistake makes the page-builder visible only on `post` pages, ignoring other post types.