### PR TITLE
Tabs: correct spacing

### DIFF
--- a/framework/static/css/backend-options.css
+++ b/framework/static/css/backend-options.css
@@ -58,7 +58,7 @@ Included on pages where backend options are rendered
 
 .fw-options-tabs-wrapper > .fw-options-tabs-list {
 	border-bottom: 1px solid #CCC;
-	padding: 0 10px;
+	/*padding: 0 10px;*/
 }
 
 .fw-options-tabs-wrapper > .fw-options-tabs-list ul,
@@ -69,8 +69,8 @@ Included on pages where backend options are rendered
 
 .fw-options-tabs-wrapper > .fw-options-tabs-list ul li {
 	float: left;
-	margin-right: 6px;
 }
+
 body.rtl .fw-options-tabs-wrapper > .fw-options-tabs-list ul li {
 	float: right;
 	margin-right: 0px;
@@ -95,7 +95,7 @@ body.rtl .fw-options-tabs-wrapper > .fw-options-tabs-list ul li {
 }
 
 .postbox .fw-options-tabs-wrapper > .fw-options-tabs-list {
-	padding-top: 10px;
+	padding: 10px 10px 0 10px;
 }
 
 .postbox .fw-options-tabs-wrapper > .fw-options-tabs-list ul li a.nav-tab {

--- a/framework/static/css/fw.css
+++ b/framework/static/css/fw.css
@@ -3036,7 +3036,7 @@ body.wp-customizer > div:not(.fw-modal) > .media-modal-backdrop {
 /* tabs fixes */
 
 .fw-modal .fw-options-tabs-first-level > .fw-options-tabs-list {
-	padding-top: 20px;
+	padding: 20px 10px 0 10px;
 }
 
 .fw-modal .fw-options-tabs-wrapper > .fw-options-tabs-contents > .fw-inner > .fw-options-tab > .fw-options-tabs-wrapper > .fw-options-tabs-list {


### PR DESCRIPTION
This commit fixes the tab spacing, Unyson tabs will look now like wordpress native tabs.

Now we have this big spacing for tabs:
<img width="445" alt="theme_settings_ _wordpress_4_ _wordpress" src="https://cloud.githubusercontent.com/assets/8998558/16668147/7cf5f280-4498-11e6-83e7-552badbbef8d.png">

This is the native wordpress spacing:
<img width="470" alt="menus_ _wordpress_4_ _wordpress" src="https://cloud.githubusercontent.com/assets/8998558/16668154/819026bc-4498-11e6-8601-67d299907506.png">
