### PR TITLE
Add hide-bottom-border for options in tabs.

### DIFF
--- a/framework/static/css/backend-options.css
+++ b/framework/static/css/backend-options.css
@@ -881,6 +881,10 @@ body.rtl .fw-postbox .handlediv:before {
 	border-bottom: 1px solid #eeeeee;
 }
 
+.fw-backend-option-design-default.fw-bottom-border-hidden {
+	border-bottom-color: transparent;
+}
+
 .fw-force-xs .fw-backend-option-design-default {
 	padding: 15px 12px;
 }

--- a/framework/views/backend-option-design-default.php
+++ b/framework/views/backend-option-design-default.php
@@ -93,6 +93,11 @@
 			$classes['input']['responsive'] = 'fw-col-xs-12';
 			$classes['desc']['responsive']  = 'fw-col-xs-12';
 		}
+
+		$hide_bottom_border = fw_akg( 'hide-bottom-border', $option, false );
+		if( $hide_bottom_border ) {
+			$classes['option'][] = 'fw-bottom-border-hidden';
+		}
 	}
 
 	/** Additional classes for input div */


### PR DESCRIPTION
In some cases we need to hide bottom border in tabs.

![First](https://i.gyazo.com/34fe915f95530c0a32cf9f38a1e58c9e.png)

to

![Second](https://i.gyazo.com/f380365f07ec498f1f63761f13505d4d.png)

options.php

```php
'ads' => array(
    'type' => 'tab',
    'title' => __( 'Advanced Design Settings', 'fw' ),
    'options' => array(
	    'padding' => array(
		    'type'  => 'short-text',
		    'label' => __( 'Content Padding', 'fw' ),
		    'desc' => __( 'Add padding to shortcode.', 'fw' ),
		    'hide-bottom-border' => true,
	    ),
    ),
),
```