### PR TITLE
introduce FW_Ext_Download_Source abstraction

### DIFF
--- a/framework/core/components/extensions/manager/available-extensions.php
+++ b/framework/core/components/extensions/manager/available-extensions.php
@@ -13,11 +13,13 @@ $extensions = array(
 		'description' => __( "Let's you easily build countless pages with the help of the drag and drop visual page builder that comes with a lot of already created shortcodes.", 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/page-builder.jpg',
 		'download'    => array(
-			'github' => array(
-				'user_repo' => $github_account . '/Unyson-PageBuilder-Extension',
-			),
+			'source' => 'github',
+			'opts' => array(
+				'user_repo' => $github_account . '/Unyson-PageBuilder-Extension'
+			)
 		),
 	),
+
 	'wp-shortcodes' => array(
 		'display'     => true,
 		'parent'      => 'shortcodes',
@@ -28,11 +30,13 @@ $extensions = array(
 		),
 		'thumbnail'   => $thumbnails_uri . '/wp-shortcodes.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => 'ThemeFuse/Unyson-WP-Shortcodes-Extension',
 			),
 		),
 	),
+
 	'backups' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -40,11 +44,13 @@ $extensions = array(
 		'description' => __( 'This extension lets you create an automated backup schedule, import demo content or even create a demo content archive for migration purposes.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/backups.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Backups-Extension',
 			),
 		),
 	),
+
 	'sidebars' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -52,11 +58,13 @@ $extensions = array(
 		'description' => __( 'Brings a new layer of customization freedom to your website by letting you add more than one sidebar to a page, or different sidebars on different pages.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/sidebars.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Sidebars-Extension',
 			),
 		),
 	),
+
 	'slider' => array(
 		'display'     => true,
 		'parent'      => 'media',
@@ -64,11 +72,13 @@ $extensions = array(
 		'description' => __( 'Adds a sliders module to your website from where you\'ll be able to create different built in jQuery sliders for your homepage and rest of the pages.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/sliders.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Sliders-Extension',
 			),
 		),
 	),
+
 	'portfolio' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -76,11 +86,13 @@ $extensions = array(
 		'description' => __( 'This extension will add a fully fledged portfolio module that will let you display your projects using the built in portfolio pages.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/portfolio.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Portfolio-Extension',
 			),
 		),
 	),
+
 	'megamenu' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -88,11 +100,13 @@ $extensions = array(
 		'description' => __( 'The Mega Menu extension adds a user-friendly drop down menu that will let you easily create highly customized menu configurations.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/mega-menu.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-MegaMenu-Extension',
 			),
 		),
 	),
+
 	'breadcrumbs' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -100,11 +114,13 @@ $extensions = array(
 		'description' => __( 'Creates a simplified navigation menu for the pages that can be placed anywhere in the theme. This will make navigating the website much easier.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/breadcrumbs.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Breadcrumbs-Extension',
 			),
 		),
 	),
+
 	'seo' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -112,11 +128,13 @@ $extensions = array(
 		'description' => __( 'This extension will enable you to have a fully optimized WordPress website by adding optimized meta titles, keywords and descriptions.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/seo.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-SEO-Extension',
 			),
 		),
 	),
+
 	'events' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -124,11 +142,13 @@ $extensions = array(
 		'description' => __( 'This extension adds a fully fledged Events module to your theme. It comes with built in pages that contain a calendar where events can be added.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/events.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Events-Extension',
 			),
 		),
 	),
+
 	'analytics' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -136,11 +156,13 @@ $extensions = array(
 		'description' => __( 'Enables the possibility to add the Google Analytics tracking code that will let you get all the analytics about visitors, page views and more.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/analytics.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Analytics-Extension',
 			),
 		),
 	),
+
 	'feedback' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -148,11 +170,13 @@ $extensions = array(
 		'description' => __( 'Adds the possibility to leave feedback (comments, reviews and rating) about your products, articles, etc. This replaces the default comments system.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/feedback.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Feedback-Extension',
 			),
 		),
 	),
+
 	'learning' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -160,11 +184,13 @@ $extensions = array(
 		'description' => __( 'This extension adds a Learning module to your theme. Using this extension you can add courses, lessons and tests for your users to take.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/learning.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Learning-Extension',
 			),
 		),
 	),
+
 	'shortcodes' => array(
 		'display'     => false,
 		'parent'      => null,
@@ -172,11 +198,13 @@ $extensions = array(
 		'description' => '',
 		'thumbnail'   => 'about:blank',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Shortcodes-Extension',
 			),
 		),
 	),
+
 	'builder' => array(
 		'display'     => false,
 		'parent'      => null,
@@ -184,11 +212,13 @@ $extensions = array(
 		'description' => '',
 		'thumbnail'   => 'about:blank',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Builder-Extension',
 			),
 		),
 	),
+
 	'forms' => array(
 		'display'     => false,
 		'parent'      => null,
@@ -196,11 +226,13 @@ $extensions = array(
 		'description' => __( 'This extension adds the possibility to create a contact form. Use the drag & drop form builder to create any contact form you\'ll ever want or need.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/forms.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Forms-Extension',
 			),
 		),
 	),
+
 	'mailer' => array(
 		'display'     => false,
 		'parent'      => null,
@@ -208,11 +240,13 @@ $extensions = array(
 		'description' => __( 'This extension will let you set some global email options and it is used by other extensions (like Forms) to send emails.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/mailer.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Mailer-Extension',
 			),
 		),
 	),
+
 	'social' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -220,11 +254,13 @@ $extensions = array(
 		'description' => __( 'Use this extension to configure all your social related APIs. Other extensions will use the Social extension to connect to your social accounts.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/social.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Social-Extension',
 			),
 		),
 	),
+
 	'backup' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -232,11 +268,13 @@ $extensions = array(
 		'description' => __( 'This extension lets you set up daily, weekly or monthly backup schedule. You can choose between a full backup or a data base only backup.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/backup.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Backup-Extension',
 			),
 		),
 	),
+
 	'media' => array(
 		'display'     => false,
 		'parent'      => null,
@@ -244,11 +282,13 @@ $extensions = array(
 		'description' => '',
 		'thumbnail'   => 'about:blank',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Empty-Extension',
 			),
 		),
 	),
+
 	'population-method' => array(
 		'display'     => false,
 		'parent'      => 'media',
@@ -256,11 +296,13 @@ $extensions = array(
 		'description' => '',
 		'thumbnail'   => 'about:blank',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-PopulationMethods-Extension',
 			),
 		),
 	),
+
 	'styling' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -268,11 +310,13 @@ $extensions = array(
 		'description' => __( 'This extension lets you control the website visual style. Starting from predefined styles to changing specific fonts and colors across the website.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/styling.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Styling-Extension',
 			),
 		),
 	),
+
 	'translation' => array(
 		'display'     => true,
 		'parent'      => null,
@@ -280,9 +324,11 @@ $extensions = array(
 		'description' => __( 'This extension lets you translate your website in any language or even add multiple languages for your users to change at their will from the front-end.', 'fw' ),
 		'thumbnail'   => $thumbnails_uri . '/translation.jpg',
 		'download'    => array(
-			'github' => array(
+			'source' => 'github',
+			'opts' => array(
 				'user_repo' => $github_account . '/Unyson-Translation-Extension',
-			),
+			)
 		),
 	),
 );
+

--- a/framework/core/components/extensions/manager/includes/available-ext/class-fw-available-extension.php
+++ b/framework/core/components/extensions/manager/includes/available-ext/class-fw-available-extension.php
@@ -38,7 +38,7 @@ class FW_Available_Extension extends FW_Type {
 	/**
 	 * @var array {id: data}
 	 */
-	private $download_sources = array();
+	private $download_source = array();
 
 	/**
 	 * @return string
@@ -96,11 +96,14 @@ class FW_Available_Extension extends FW_Type {
 		$this->thumbnail = $thumbnail;
 	}
 
-	public function get_download_sources() {
-		return $this->download_sources;
+	public function get_download_source() {
+		return $this->download_source;
 	}
 
-	public function add_download_source($id, $data) {
-		$this->download_sources[$id] = $data;
+	public function set_download_source($id, $data) {
+		$this->download_source = array(
+			'source' => $id,
+			'opts' => $data
+		);
 	}
 }

--- a/framework/core/components/extensions/manager/includes/download-source/class--fw-ext-download-source-register.php
+++ b/framework/core/components/extensions/manager/includes/download-source/class--fw-ext-download-source-register.php
@@ -1,0 +1,32 @@
+<?php if (! defined('FW')) { die('Forbidden'); }
+
+class _FW_Ext_Download_Source_Register extends FW_Type_Register
+{
+	protected function validate_type( FW_Type $type ) {
+		return $type instanceof FW_Ext_Download_Source;
+	}
+
+	public function by_source(FW_Access_Key $access_key, $source) {
+		if (!isset($this->access_keys[$access_key->get_key()])) {
+			trigger_error('Method call denied', E_USER_ERROR);
+		}
+
+		$download_source = null;
+
+		foreach ($this->types as $download_source) {
+			if ($download_source->get_type() === $source) {
+				$download_source = $download_source;
+			}
+		}
+
+		if (! $download_source) {
+			trigger_error(
+				"There's no such download source " . $source,
+				E_USER_ERROR
+			);
+		}
+
+		return $download_source;
+	}
+}
+

--- a/framework/core/components/extensions/manager/includes/download-source/class--fw-ext-download-source.php
+++ b/framework/core/components/extensions/manager/includes/download-source/class--fw-ext-download-source.php
@@ -1,0 +1,19 @@
+<?php if (! defined('FW')) { die('Forbidden'); }
+
+/**
+ * User to specify multiple download sources for an extension.
+ * @since 2.5.12
+ */
+abstract class FW_Ext_Download_Source extends FW_Type
+{
+	/**
+	 * Perform the actual download.
+	 * It should download, by convention, a zip file which absolute path
+	 * is $path.
+	 *
+	 * @param array $opts
+	 * @param string $path Absolute file of the future ZIP file
+	 */
+	abstract public function download(array $opts, $zip_path);
+}
+

--- a/framework/core/components/extensions/manager/includes/download-source/types/class-fw-github-download-source.php
+++ b/framework/core/components/extensions/manager/includes/download-source/types/class-fw-github-download-source.php
@@ -1,0 +1,184 @@
+<?php if (! defined('FW')) { die('Forbidden'); }
+
+class FW_Ext_Github_Download_Source extends FW_Ext_Download_Source
+{
+	private $source_key = 'github';
+
+	private $download_timeout = 300;
+
+	public function get_type() {
+		return $this->source_key;
+	}
+
+	public function download(array $opts, $zip_path) {
+		$wp_error_id = 'fw_ext_github_download_source';
+		$theme_ext_requirements = fw()->theme->manifest->get('requirements/extensions');
+
+		/** @var WP_Filesystem_Base $wp_filesystem */
+		global $wp_filesystem;
+
+		$extension_name = $opts['extension_name'];
+		$extension_title = $opts['extension_title'];
+
+		if (empty($opts['user_repo'])) {
+			return new WP_Error(
+				$wp_error_id,
+				sprintf(__('"%s" extension github source "user_repo" parameter is required', 'fw'), $extension_title)
+			);
+		}
+
+
+		{
+			$transient_name = 'fw_ext_mngr_gh_dl';
+			$transient_ttl  = HOUR_IN_SECONDS;
+
+			$cache = get_site_transient($transient_name);
+
+			if ($cache === false) {
+				$cache = array();
+			}
+		}
+
+		if (isset($cache[ $opts['user_repo'] ])) {
+			$download_link = $cache[ $opts['user_repo'] ]['zipball_url'];
+		} else {
+			$http = new WP_Http();
+
+			if (
+				isset($theme_ext_requirements[$extension_name])
+				&&
+				isset($theme_ext_requirements[$extension_name]['max_version'])
+			) {
+				$tag = 'tags/v'. $theme_ext_requirements[$extension_name]['max_version'];
+			} else {
+				$tag = 'latest';
+			}
+
+			$response = $http->get(
+				apply_filters('fw_github_api_url', 'https://api.github.com')
+				. '/repos/'. $opts['user_repo'] .'/releases/'. $tag
+			);
+
+			unset($http);
+
+			$response_code = intval(wp_remote_retrieve_response_code($response));
+
+			if ($response_code !== 200) {
+				if ($response_code === 403) {
+					if ($json_response = json_decode($response['body'], true)) {
+						return new WP_Error(
+							$wp_error_id,
+							__('Github error:', 'fw') .' '. $json_response['message']
+						);
+					} else {
+						return new WP_Error(
+							$wp_error_id,
+							sprintf(
+								__( 'Failed to access Github repository "%s" releases. (Response code: %d)', 'fw' ),
+								$opts['user_repo'], $response_code
+							)
+						);
+					}
+				} elseif ($response_code) {
+					return new WP_Error(
+						$wp_error_id,
+						sprintf(
+							__( 'Failed to access Github repository "%s" releases. (Response code: %d)', 'fw' ),
+							$opts['user_repo'], $response_code
+						)
+					);
+				} elseif (is_wp_error($response)) {
+					return new WP_Error(
+						$wp_error_id,
+						sprintf(
+							__( 'Failed to access Github repository "%s" releases. (%s)', 'fw' ),
+							$opts['user_repo'], $response->get_error_message()
+						)
+					);
+				} else {
+					return new WP_Error(
+						$wp_error_id,
+						sprintf(
+							__( 'Failed to access Github repository "%s" releases.', 'fw' ),
+							$opts['user_repo']
+						)
+					);
+				}
+			}
+
+			$release = json_decode($response['body'], true);
+
+			unset($response);
+
+			if (empty($release)) {
+				return new WP_Error(
+					$wp_error_id,
+					sprintf(
+						__('"%s" extension github repository "%s" has no releases.', 'fw'),
+						$extension_title, $opts['user_repo']
+					)
+				);
+			}
+
+			{
+				$cache[ $opts['user_repo'] ] = array(
+					'zipball_url' => 'https://github.com/'. $opts['user_repo'] .'/archive/'. $release['tag_name'] .'.zip',
+					'tag_name' => $release['tag_name']
+				);
+
+				set_site_transient($transient_name, $cache, $transient_ttl);
+			}
+
+			$download_link = $cache[ $opts['user_repo'] ]['zipball_url'];
+
+
+			unset($release);
+		}
+
+		{
+			$http = new WP_Http();
+
+			$response = $http->request($download_link, array(
+				'timeout' => $this->download_timeout,
+			));
+
+			unset($http);
+
+			if (($response_code = intval(wp_remote_retrieve_response_code($response))) !== 200) {
+				if ($response_code) {
+					return new WP_Error(
+						$wp_error_id,
+						sprintf( __( 'Cannot download the "%s" extension zip. (Response code: %d)', 'fw' ),
+							$extension_title, $response_code
+						)
+					);
+				} elseif (is_wp_error($response)) {
+					return new WP_Error(
+						$wp_error_id,
+						sprintf( __( 'Cannot download the "%s" extension zip. %s', 'fw' ),
+							$extension_title,
+							$response->get_error_message()
+						)
+					);
+				} else {
+					return new WP_Error(
+						$wp_error_id,
+						sprintf( __( 'Cannot download the "%s" extension zip.', 'fw' ),
+							$extension_title
+						)
+					);
+				}
+			}
+
+			// save zip to file
+			if (!$wp_filesystem->put_contents($zip_path, $response['body'])) {
+				return new WP_Error(
+					$wp_error_id,
+					sprintf(__('Cannot save the "%s" extension zip.', 'fw'), $extension_title)
+				);
+			}
+
+			unset($response);
+		}
+	}
+}

--- a/framework/core/components/extensions/manager/includes/download-source/types/init.php
+++ b/framework/core/components/extensions/manager/includes/download-source/types/init.php
@@ -1,0 +1,15 @@
+<?php if (! defined('FW')) { die('Forbidden'); }
+
+if ( ! function_exists( '_action_fw_register_ext_download_sources' ) ) {
+	function _action_fw_register_ext_download_sources(_FW_Ext_Download_Source_Register $download_sources) {
+		$dir = dirname(__FILE__);
+
+		require_once $dir . '/class-fw-github-download-source.php';
+		$download_sources->register(new FW_Ext_Github_Download_Source());
+	}
+}
+
+add_action(
+	'fw_register_ext_download_sources',
+	'_action_fw_register_ext_download_sources'
+);

--- a/framework/helpers/type/class-fw-type-register.php
+++ b/framework/helpers/type/class-fw-type-register.php
@@ -18,13 +18,13 @@ abstract class FW_Type_Register {
 	/**
 	 * @var FW_Type[]
 	 */
-	private $types = array();
+	protected $types = array();
 
 	/**
 	 * Only these access keys will be able to access the registered types
 	 * @var array {'key': true}
 	 */
-	private $access_keys = array();
+	protected $access_keys = array();
 
 	final public function __construct($access_keys) {
 		{


### PR DESCRIPTION
Introduce the `FW_Ext_Download_Source` abstraction. Also, add the `fw_register_ext_download_sources` you can hook into in order to declare more Download Sources for your extensions.

This one has nothing to do with the update process of the extensions.

This pull request complements this https://github.com/ThemeFuse/Unyson/commit/af91e39f14784413134f97f455fa00feb187b8fb nicely.

<hr>

Any feedback or suggestion is welcome. Test please!
