### PR TITLE
Resolve issue when path match incorrect.

### DIFF
--- a/framework/helpers/class-fw-wp-filesystem.php
+++ b/framework/helpers/class-fw-wp-filesystem.php
@@ -145,7 +145,7 @@ class FW_WP_Filesystem
 		$real_path = fw_fix_path($real_path);
 
 		foreach (self::get_base_dirs_map() as $base_real_path => $base_wp_filesystem_path) {
-			$prefix_regex = '/^'. preg_quote($base_real_path, '/') .'/';
+			$prefix_regex = '/^'. preg_quote($base_real_path, '/') .'\//';
 
 			// check if path is inside base path
 			if (!preg_match($prefix_regex, $real_path)) {
@@ -182,7 +182,7 @@ class FW_WP_Filesystem
 		$wp_filesystem_path = fw_fix_path($wp_filesystem_path);
 
 		foreach (self::get_base_dirs_map() as $base_real_path => $base_wp_filesystem_path) {
-			$prefix_regex = '/^'. preg_quote($base_wp_filesystem_path, '/') .'/';
+			$prefix_regex = '/^'. preg_quote($base_wp_filesystem_path, '/') .'\//';
 
 			// check if path is inside base path
 			if (!preg_match($prefix_regex, $wp_filesystem_path)) {
@@ -254,7 +254,7 @@ class FW_WP_Filesystem
 		$path = false;
 
 		foreach (self::get_base_dirs_map() as $base_real_path => $base_wp_filesystem_path) {
-			$prefix_regex = '/^'. preg_quote($base_wp_filesystem_path, '/') .'/';
+			$prefix_regex = '/^'. preg_quote($base_wp_filesystem_path, '/') .'\//';
 
 			// check if path is inside base path
 			if (!preg_match($prefix_regex, $wp_filesystem_dir_path)) {


### PR DESCRIPTION
Resolve issue when paths returned from class-fw-wp-filesystem::get_base_dirs_map() return partial match against $wp_filesystem_dir_path causing a false positive on partial paths with current regex.

    FILEPATH: `/var/www/vhosts/domain.co.uk/httpdocs/wp-content/plugins/unyson/tmp`
    REGEX: `/^\/var\/www\/vhosts\/domain\.co\.uk\/httpdocs\/wp/`
    INCORRECT HIT (abspath()): /var/www/vhosts/domain.co.uk/httpdocs/wp - causing a replace to return `-content/plugins/unyson/tmp`
    REQUIRED: `/var/www/vhosts/domain.co.uk/httpdocs/wp-content/plugins`

Solution: Match the trailing slash on the regex, to ensure correct path is matched.