### PR TITLE
Removed reference

### DIFF
--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -10,7 +10,7 @@
  * @param string $keys_delimiter
  * @return null|mixed
  */
-function fw_akg($keys, &$array_or_object, $default_value = null, $keys_delimiter = '/') {
+function fw_akg($keys, $array_or_object, $default_value = null, $keys_delimiter = '/') {
 	if (!is_array($keys)) {
 		$keys = explode( $keys_delimiter, (string) $keys );
 	}


### PR DESCRIPTION
Made few tests with huge associative array, and with deep search (15 nesting steps ) and the memory test result is the same. It seems php has own optimization tools.