### PR TITLE
Add the same options for different picker keys.

### DIFF
--- a/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
+++ b/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
@@ -214,6 +214,11 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 				E_USER_ERROR
 			);
 		}
+		
+		/**
+		 * @since 2.6.11
+		 */
+		$option = $this->prepare_choices($option);
 
 		{
 			reset($option['picker']);
@@ -282,6 +287,35 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 		);
 
 		return array_merge($picker_group, $choices_groups);
+	}
+	
+	/**
+	 * Prepare `choices` array.
+	 *
+	 * @since 2.6.11
+	 * @param array $option Options.
+	 * @return array
+	 */
+	protected function prepare_choices($option) {
+		$result = array();
+		$choices = fw_akg('choices', $option);
+
+		if (is_array($choices)) {
+			foreach ($choices as $key => $settings) {
+				if (isset($settings['for']) && isset($settings['options'])) {
+					if (is_array($settings['for'])) {
+						foreach($settings['for'] as $name) {
+							$result[$name] = $settings['options'];
+						}
+					}
+				} else {
+					$result[$key] = $settings;
+				}
+			}
+		}
+
+		fw_aks('choices', $result, $option);
+		return $option;
 	}
 
 	/**

--- a/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
+++ b/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
@@ -306,7 +306,7 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 					if (is_array($settings['for'])) {
 						// Insert location: after/before.
 						$location = fw_akg('location', $settings, 'before');
-						foreach($settings['for'] as $name) {
+						foreach ($settings['for'] as $name) {
 							if (isset($choices[$name])) {
 								if ('before' === $location) {
 									$result[$name] = array_merge(
@@ -323,7 +323,7 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 						}
 					}
 				} else {
-					if ( ! $result[$key] ) {
+					if ( ! isset($result[$key]) ) {
 						$result[$key] = $settings;
 					}
 				}

--- a/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
+++ b/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
@@ -304,12 +304,28 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 			foreach ($choices as $key => $settings) {
 				if (isset($settings['for']) && isset($settings['options'])) {
 					if (is_array($settings['for'])) {
+						// Insert location: after/before.
+						$location = fw_akg('location', $settings, 'before');
 						foreach($settings['for'] as $name) {
-							$result[$name] = $settings['options'];
+							if (isset($choices[$name])) {
+								if ('before' === $location) {
+									$result[$name] = array_merge(
+										$settings['options'], $choices[$name]
+									);
+								} else {
+									$result[$name] = array_merge(
+										$choices[$name], $settings['options']
+									);
+								}
+							} else {
+								$result[$name] = $settings['options'];
+							}
 						}
 					}
 				} else {
-					$result[$key] = $settings;
+					if ( ! $result[$key] ) {
+						$result[$key] = $settings;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Issue: #2247 

## options.php

```php
$options = array(
	'elements' => array(
		'type'    => 'multi-picker',
		'label'   => false,
		'desc'    => false,
		'picker'  => array(
			'selected' => array(
				'label'   => __( 'Modify', 'fw' ),
				'type'    => 'radio',
				'inline'  => true,
				'value'   => 'link',
				'choices' => array(
					'logo' => __( 'Link', 'fw' ),
					'header-one' => __( 'Header One', 'fw' ),
					'header-two' => __( 'Header Two', 'fw' ),
					'footer' => __( 'Footer', 'fw' ),
				),
			),
		),

		'choices' => array(

			'logo' => array(
				'title' => array('type' => 'text'),
			),

			// Options for `header-one` and `header-two`
			array(
				'for' => array('header-one', 'header-two'),
				'options'   => array(
					'links' => array(
						'label' => __( 'Header Text', 'fw' ),
						'type'  => 'text',
						'value' => 'some text',
					),
				),
			),

			'footer' => array(
				'copyright' => array('type' => 'text'),
			),
		),
	),
);
```

## Result:
![Result](https://i.gyazo.com/1cddcc446083fd45524b0a9f053bdbec.gif)