### PR TITLE
fix scrollTop jump issue for fw.Modal

### DIFF
--- a/framework/static/js/fw.js
+++ b/framework/static/js/fw.js
@@ -730,6 +730,8 @@ fw.getQueryString = function(name) {
 				uploader: false
 			});
 
+			patchMediaFramesModalToDoTheFocusCorrectly( this.frame );
+
 			var modal = this;
 
 			this.frame.once('ready', function(){
@@ -977,6 +979,65 @@ fw.getQueryString = function(name) {
 			$frame.css('overflow-y', 'hidden');
 		}
 	});
+
+	// https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6800
+	// When you execute frame.modal.open() - the modal tries to switch focus
+	// to its $el. Actually, this switches the scrollTop property for window.
+	//
+	// In order to prevent that we'll have to monkey patch the frame.modal.open
+	// method and do the focus properly - that's what this function does
+	function patchMediaFramesModalToDoTheFocusCorrectly (frame) {
+		if (! frame.modal) return;
+
+		frame.modal.open = function () {
+			var $el = this.$el,
+				options = this.options,
+				mceEditor;
+
+			if ( $el.is(':visible') ) {
+				return this;
+			}
+
+			this.clickedOpenerEl = document.activeElement;
+
+			if ( ! this.views.attached ) {
+				this.attach();
+			}
+
+			// If the `freeze` option is set, record the window's scroll position.
+			if ( options.freeze ) {
+				this._freeze = {
+					scrollTop: jQuery( window ).scrollTop()
+				};
+			}
+
+			// Disable page scrolling.
+			jQuery( 'body' ).addClass( 'modal-open' );
+
+			$el.show();
+
+			// Try to close the onscreen keyboard
+			if ( 'ontouchend' in document ) {
+				if ( ( mceEditor = window.tinymce && window.tinymce.activeEditor )  && ! mceEditor.isHidden() && mceEditor.iframeElement ) {
+					mceEditor.iframeElement.focus();
+					mceEditor.iframeElement.blur();
+
+					setTimeout( function() {
+						mceEditor.iframeElement.blur();
+					}, 100 );
+				}
+			}
+
+			// this part is changed from the original method
+			// this.$el.focus();
+			// http://stackoverflow.com/a/11676673/3220977
+			var initialX = window.scrollX, initialY = window.scrollY;
+			this.$el.focus();
+			window.scrollTo(initialX, initialY);
+
+			return this.propagate('open');
+		}
+	}
 })();
 
 /**


### PR DESCRIPTION
Long story short, this pull request fixes the scroll jumping on open/close for `fw.Modal` (thus `fw.OptionsModal` gets also fixed).

[**BEFORE**](https://www.screenmailer.com/v/o201KLQ9pKOvBaU) | [**AFTER**](https://www.screenmailer.com/v/DgUzmLbJQYaF3c8)

Fixes #2261

<hr>

What was the problem:

`fw.Modal` uses [`wp.media.view.MediaFrame`](https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6255), which in turn uses [`wp.media.view.Modal`](https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6688). When you do `(new fw.Modal()).open()` you're automatically calling `open()` method of the `wp.media.view.Modal`, because of the [inheritance chain](https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6471-L6481).

It turns out that `Modal`'s `open()` method, at its end, does this [strange thing](https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6800):

```javascript
this.$el.focus()
```

The `focus()` method call is the one who forced the body to jump down - if you remove that line - you're fine. They even introduced a `freeze` option, which [saves](https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6777-L6781) the current scroll position and then [restores](https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6832-L6834) it. But this didn't fixed the underlying problem.

The solution is to remove this `focus` action at all, or do it in a [smart way](http://stackoverflow.com/a/11676673/3220977). That's what this pull request does - `focus`es the modal a bit more carefully.