### PR TITLE
respect $_SERVER for the cases when WP_CLI is defined

### DIFF
--- a/framework/bootstrap.php
+++ b/framework/bootstrap.php
@@ -6,7 +6,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
 	$_SERVER['SERVER_PORT'] = '80';
 }
 
-
 if (defined('FW')) {
 	/**
 	 * The framework is already loaded.

--- a/framework/bootstrap.php
+++ b/framework/bootstrap.php
@@ -1,5 +1,12 @@
 <?php if (!defined('ABSPATH')) die('Forbidden');
 
+if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
+	$_SERVER['HTTP_HOST'] = 'unyson.io';
+	$_SERVER['SERVER_NAME'] = 'unyson';
+	$_SERVER['SERVER_PORT'] = '80';
+}
+
+
 if (defined('FW')) {
 	/**
 	 * The framework is already loaded.

--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -1314,15 +1314,6 @@ function fw_get_google_fonts_v2() {
 function fw_current_url() {
 	static $url = null;
 
-
-	if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
-		$_SERVER['HTTP_HOST'] = 'wp-cli.org';
-	}
-
-	if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
-		$_SERVER['HTTP_HOST'] = 'wp-cli.org';
-	}
-
 	if ( $url === null ) {
 		$url = 'http://';
 

--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -1314,6 +1314,15 @@ function fw_get_google_fonts_v2() {
 function fw_current_url() {
 	static $url = null;
 
+
+	if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
+		$_SERVER['HTTP_HOST'] = 'wp-cli.org';
+	}
+
+	if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
+		$_SERVER['HTTP_HOST'] = 'wp-cli.org';
+	}
+
 	if ( $url === null ) {
 		$url = 'http://';
 


### PR DESCRIPTION
Respects the $_SERVER superglobal in cli commands. The [official](https://make.wordpress.org/cli/handbook/common-issues/#php-notice-undefined-index-on-_server-superglobal) docs.