### PR TITLE
introduce a replacement for Backbone.Events

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -294,7 +294,7 @@ final class _FW_Component_Backend {
 		wp_register_script(
 			'fw-events',
 			fw_get_framework_directory_uri( '/static/js/fw-events.js' ),
-			array( 'backbone' ),
+			array(),
 			fw()->manifest->get_version(),
 			true
 		);


### PR DESCRIPTION
This pull request aims to remove the [`Backbone.Events`](https://github.com/ThemeFuse/Unyson/blob/13037e1ef51cee31244b4b5818683728e4f3c745/framework/static/js/fw-events.js#L6) dependency away from [`fwEvents`](http://manual.unyson.io/en/latest/helpers/javascript.html#events). This is just a drop-in replacement which should work the same as before, without breaking changes.

I wanted to keep the implementation as simple as possible but it is a notable change which is not that small, because I wanted to keep backwards compatibility with the old implementation. Which of these features we can get rid of?

1. #### Space separated events

```javascript
fwEvents.on('event1 event2 event3', function (data) {
  // execute this for each of those events
});
```

2. #### Events with object literal syntax

```javascript
fwEvents.on({
  event1: function (data) {},
  event2: function (data) {},
  event3: function (data) {}
});
```

3. #### Third parameter for `fwEvents.on()` and `fwEvents.one` which is `context` - [docs](http://backbonejs.org/#Events-on)

```javascript
fwEvents.on('event-name', function (data) {
  this // refers to myObject passed in as third parameter
}, myObject);
```

4. #### attach a listener to `all` event. This listener will be called on each trigger, you'll receive type as a argument 

This feature provides a possible implementation for the logging functionality with `fwEvents` does.

```javascript
fwEvents.on('all', function (eventType, data) {
  eventType // this contains event type that got triggered as a string
}, myObject);
```

This code will be simplified a lot by removing any of those syntaxes.
