### PR TITLE
use console.error for better stack traces

### DIFF
--- a/framework/static/js/fw-events.js
+++ b/framework/static/js/fw-events.js
@@ -141,10 +141,15 @@ var fwEvents = new (function(){
 					(_events[eventName] || []).map(dispatchSingleEvent);
 					(_events['all'] || []).map(dispatchSingleEvent);
 				} catch (e) {
-					console.log('[Events] Exception ', {exception: e});
+					console.log(
+						"%c [Events] Exception raised. Please contact support in https://github.com/ThemeFuse/Unyson/issues/new. Don't forget to attach this stack trace to the issue.",
+						"color: red; font-weight: bold;"
+					);
 
-					if (console.trace) {
-						console.trace();
+					if (typeof console !== 'undefined') {
+						console.error(e)
+					} else {
+						throw e;
 					}
 				}
 


### PR DESCRIPTION
![](https://d2ppvlu71ri8gs.cloudfront.net/items/1v223z1K2p1F402D3X2F/Screen%20Shot%202017-04-25%20at%2010.47.16%20AM.png?v=98e89d0a)