### PR TITLE
a more explicit .off() which handles contexts

### DIFF
--- a/framework/static/js/fw-events.js
+++ b/framework/static/js/fw-events.js
@@ -4,7 +4,7 @@
 var fwEvents = new (function(){
 	var _events = {};
 	var currentIndentation = 1;
-	var debug = true;
+	var debug = false;
 
 	/**
 	 * Make log helper public


### PR DESCRIPTION
We've got to support code like [that](https://github.com/ThemeFuse/Unyson-PageBuilder-Extension/blob/7d647038d3aa153348563b6eb98b5c4635682866/includes/page-builder/static/js/modal-save-all.js#L9-L14):

```javascript
fwEvents.off(null, null, this);
```

Long story short, we need proper handling for contexts while doing events `.off()`.
That's what this pull request tries to do.