### PR TITLE
Check if `array` has been passed to sanitize method.

### DIFF
--- a/framework/includes/customizer/class--fw-customizer-setting-option.php
+++ b/framework/includes/customizer/class--fw-customizer-setting-option.php
@@ -18,6 +18,10 @@ class _FW_Customizer_Setting_Option extends WP_Customize_Setting {
 	}
 
 	public function sanitize($value) {
+		if(is_array($value) {
+			return null;
+		}
+		   
 		$value = json_decode($value, true);
 
 		if (is_null($value) || !is_array($value)) {


### PR DESCRIPTION
Sanitize method should have a `string` passed to it, put sometimes, somehow during an ajax call inside customizer an empty array gets passed it. If that's the case, return with the value `null` immediately.
closes #2522