### PR TITLE
addable box doesn't work with multiple wp-editor

### DIFF
--- a/framework/includes/option-types/addable-box/static/js/scripts.js
+++ b/framework/includes/option-types/addable-box/static/js/scripts.js
@@ -259,10 +259,14 @@ jQuery(document).ready(function ($) {
 				&&
 				$newBox.find('.fw-option-type-wp-editor:first').length
 			) {
-				fwWpEditorRefreshIds(
-					$newBox.find('.fw-option-type-wp-editor textarea:first').attr('id'),
-					$newBox
-				);
+				$newBox.find(
+					'.fw-option-type-wp-editor textarea'
+				).toArray().map(function (textarea) {
+					fwWpEditorRefreshIds(
+						$(textarea).attr('id'),
+						$newBox
+					);
+				});
 			}
 
 			methods.initControls($newBox);


### PR DESCRIPTION
This pull request fixes the JS so that it correctly searches each `wp-editor` instance which is contained in `addable-box` and refreshes its ID.