### PR TITLE
implement hint objects for simple option types

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -345,18 +345,32 @@ final class _FW_Component_Backend {
 			);
 
 			wp_register_script(
+				'fw-reactive-options-simple-options',
+				fw_get_framework_directory_uri(
+					'/static/js/fw-reactive-options-simple-options.js'
+				),
+				array('fw', 'fw-events', 'fw-reactive-options-undefined-option'),
+				false
+			);
+
+			wp_register_script(
 				'fw-reactive-options-undefined-option',
 				fw_get_framework_directory_uri(
 					'/static/js/fw-reactive-options-undefined-option.js'
 				),
-				array('fw', 'fw-events', 'fw-reactive-options-registry'),
+				array(
+					'fw', 'fw-events', 'fw-reactive-options-registry'
+				),
 				false
 			);
 
 			wp_register_script(
 				'fw-reactive-options',
 				fw_get_framework_directory_uri('/static/js/fw-reactive-options.js'),
-				array('fw', 'fw-events', 'fw-reactive-options-undefined-option'),
+				array(
+					'fw', 'fw-events', 'fw-reactive-options-undefined-option',
+					'fw-reactive-options-simple-options'
+				),
 				false
 			);
 

--- a/framework/includes/option-types/simple.php
+++ b/framework/includes/option-types/simple.php
@@ -12,6 +12,10 @@ class FW_Option_Type_Hidden extends FW_Option_Type {
 		return 'hidden';
 	}
 
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
+	}
+
 	/**
 	 * @internal
 	 * {@inheritdoc}
@@ -75,6 +79,10 @@ class FW_Option_Type_Text extends FW_Option_Type {
 	protected function _enqueue_static( $id, $option, $data ) {
 	}
 
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
+	}
+
 	/**
 	 * @param string $id
 	 * @param array $option
@@ -117,6 +125,10 @@ class FW_Option_Type_Short_Text extends FW_Option_Type_Text {
 		return 'short-text';
 	}
 
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
+	}
+
 	/**
 	 * @param string $id
 	 * @param array $option
@@ -151,6 +163,10 @@ class FW_Option_Type_Password extends FW_Option_Type {
 	 * {@inheritdoc}
 	 */
 	protected function _enqueue_static( $id, $option, $data ) {
+	}
+
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
 	}
 
 	/**
@@ -200,6 +216,10 @@ class FW_Option_Type_Textarea extends FW_Option_Type {
 	 * {@inheritdoc}
 	 */
 	protected function _enqueue_static( $id, $option, $data ) {
+	}
+
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
 	}
 
 	/**
@@ -256,6 +276,10 @@ class FW_Option_Type_Html extends FW_Option_Type {
 	 * {@inheritdoc}
 	 */
 	protected function _enqueue_static( $id, $option, $data ) {
+	}
+
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
 	}
 
 	/**
@@ -365,6 +389,10 @@ class FW_Option_Type_Checkbox extends FW_Option_Type {
 	protected function _enqueue_static( $id, $option, $data ) {
 	}
 
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
+	}
+
 	/**
 	 * @param string $id
 	 * @param array $option
@@ -456,6 +484,10 @@ class FW_Option_Type_Checkboxes extends FW_Option_Type {
 	protected function _enqueue_static( $id, $option, $data ) {
 	}
 
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
+	}
+
 	/**
 	 * @param string $id
 	 * @param array $option
@@ -496,6 +528,7 @@ class FW_Option_Type_Checkboxes extends FW_Option_Type {
 					'name' => $option['attr']['name'] . '[' . $value . ']',
 					'value' => 'true',
 					'id' => $option['attr']['id'] . '-' . $value,
+					'data-fw-checkbox-id' => $value
 				),
 				isset( $option['value'][ $value ] ) && $option['value'][ $value ]
 					? array('checked' => 'checked') : array()
@@ -584,6 +617,10 @@ class FW_Option_Type_Radio extends FW_Option_Type {
 	 * {@inheritdoc}
 	 */
 	protected function _enqueue_static( $id, $option, $data ) {
+	}
+
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
 	}
 
 	/**
@@ -702,6 +739,10 @@ class FW_Option_Type_Select extends FW_Option_Type {
 	 * {@inheritdoc}
 	 */
 	protected function _enqueue_static( $id, $option, $data ) {
+	}
+
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
 	}
 
 	/**
@@ -995,14 +1036,17 @@ class FW_Option_Type_Select_Multiple extends FW_Option_Type_Select {
 	}
 }
 
-class FW_Option_Type_Unique extends FW_Option_Type
-{
+class FW_Option_Type_Unique extends FW_Option_Type {
 	private static $ids = array();
 	private static $should_do_regeneration = true;
 
 	public function get_type()
 	{
 		return 'unique';
+	}
+
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
 	}
 
 	protected function _get_defaults()

--- a/framework/static/js/fw-events.js
+++ b/framework/static/js/fw-events.js
@@ -4,7 +4,7 @@
 var fwEvents = new (function(){
 	var _events = {};
 	var currentIndentation = 1;
-	var debug = true;
+	var debug = false;
 
 	/**
 	 * Make log helper public

--- a/framework/static/js/fw-reactive-options-simple-options.js
+++ b/framework/static/js/fw-reactive-options-simple-options.js
@@ -1,0 +1,81 @@
+(function ($) {
+	var simpleInputs = [
+		'text',
+		'short-text',
+		'hidden',
+		'password',
+		'textarea',
+		'html',
+		'html-fixed',
+		'html-full',
+		'unique',
+		'select',
+		'short-select',
+		'gmap-key'
+	]
+
+	simpleInputs.map(function (optionType) {
+		fw.options.register(optionType, {
+			getValue: getValueForSimpleInput
+		});
+	});
+
+	function getValueForSimpleInput (optionDescriptor) {
+		return {
+			value: optionDescriptor.el.querySelector(
+				'input, textarea, select'
+			).value,
+			optionDescriptor: optionDescriptor
+		};
+	}
+
+	fw.options.register('checkbox', {
+		getValue: function (optionDescriptor) {
+			return {
+				value: optionDescriptor.el.querySelector(
+					'input.fw-option-type-checkbox'
+				).checked,
+				optionDescriptor: optionDescriptor
+			};
+		}
+	});
+
+	fw.options.register('checkboxes', {
+		getValue: function (optionDescriptor) {
+			var checkboxes = $(optionDescriptor.el).find(
+				'[type="checkbox"]'
+			).slice(1);
+
+			var value = {};
+
+			checkboxes.toArray().map(function (el) {
+				value[$(el).attr('data-fw-checkbox-id')] = el.checked;
+			});
+
+			return {
+				value: value,
+				optionDescriptor: optionDescriptor
+			};
+		}
+	});
+
+	fw.options.register('radio', {
+		getValue: function (optionDescriptor) {
+			return {
+				value: $(optionDescriptor.el).find('input:checked').val(),
+				optionDescriptor: optionDescriptor
+			};
+		}
+	});
+
+	fw.options.register('select-multiple', {
+		getValue: function (optionDescriptor) {
+			return {
+				value: $(optionDescriptor.el.querySelector(
+					'select'
+				)).val(),
+				optionDescriptor: optionDescriptor
+			};
+		}
+	});
+})(jQuery);


### PR DESCRIPTION
This pull request is a continuation for https://github.com/ThemeFuse/Unyson/pull/2603.

Here we continue our journey towards implementing fully reactive option types that don't require AJAX calls to backend in order to extract value from frontend.

The full list of implemented option types goes now:

* `text`
* `short-text`
* `hidden`
* `password`
* `textarea`
* `html`
* `html-fixed`
* `html-full`
* `unique`
* `select`
* `select-multiple`
* `short-select`
* `checkbox`
* `checkboxes`
* `radio`
* `gmap-key`

In short, this pull request covers `getValue()` for each option type defined in [`simple.php`](https://github.com/ThemeFuse/Unyson/blob/e6f36870afa974240725f19003b56111e73b5c03/framework/includes/option-types/simple.php).