### PR TITLE
implement reactivity for addable-option

### DIFF
--- a/framework/includes/option-types/addable-option/class-fw-option-type-addable-option.php
+++ b/framework/includes/option-types/addable-option/class-fw-option-type-addable-option.php
@@ -28,6 +28,10 @@ class FW_Option_Type_Addable_Option extends FW_Option_Type
 		);
 	}
 
+	protected function _get_data_for_js($id, $option, $data = array()) {
+		return false;
+	}
+
 	/**
 	 * @internal
 	 * {@inheritdoc}

--- a/framework/includes/option-types/addable-option/view.php
+++ b/framework/includes/option-types/addable-option/view.php
@@ -20,7 +20,7 @@ if ($option['sortable']) {
 	<table class="fw-option-type-addable-option-options" width="100%" cellpadding="0" cellspacing="0" border="0">
 	<?php $i = 1; ?>
 	<?php foreach($data['value'] as $option_value): ?>
-		<tr class="fw-option-type-addable-option-option">
+		<tr class="fw-option-type-addable-option-option fw-backend-options-virtual-context">
 			<td class="td-move">
 				<img src="<?php echo esc_attr($move_img_src); ?>" width="7" />
 			</td>
@@ -64,7 +64,7 @@ if ($option['sortable']) {
 		$increment_placeholder = '###-addable-option-increment-'. fw_rand_md5() .'-###';
 
 		echo fw_htmlspecialchars(
-			'<tr class="fw-option-type-addable-option-option">
+			'<tr class="fw-option-type-addable-option-option fw-backend-options-virtual-context">
 				<td class="td-move">
 					<img src="'. $move_img_src .'" width="7" />
 				</td>


### PR DESCRIPTION
This pull request continues the work from https://github.com/ThemeFuse/Unyson/pull/2639. It implements reactivity for:

*   [`addable-option`](http://manual.unyson.io/en/latest/options/built-in/addable-option.html)