### PR TITLE
Feature default label for option types

### DIFF
--- a/framework/core/extends/class-fw-option-type.php
+++ b/framework/core/extends/class-fw-option-type.php
@@ -339,6 +339,14 @@ abstract class FW_Option_Type
 	}
 
 	/**
+	 * a general purpose 'label' => false | true from options.php
+	 * @return bool | string
+	 */
+	public function _default_label($id, $option) {
+		return fw_id_to_title($id);
+	}
+
+	/**
 	 * Use this method to register a new option type
 	 *
 	 * @param string|FW_Option_Type $option_type_class

--- a/framework/core/extends/class-fw-option-type.php
+++ b/framework/core/extends/class-fw-option-type.php
@@ -341,6 +341,8 @@ abstract class FW_Option_Type
 	/**
 	 * a general purpose 'label' => false | true from options.php
 	 * @return bool | string
+	 *
+	 * @since 2.7.1
 	 */
 	public function _default_label($id, $option) {
 		return fw_id_to_title($id);

--- a/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
+++ b/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
@@ -23,7 +23,7 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 				)
 			),
 			'choices' => array(),
-			'hide_picker' => false,
+			'hide_picker' => true,
 			/**
 			 * Display separators between options
 			 */
@@ -63,6 +63,10 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 		fw()->backend->enqueue_options_static($this->prepare_option($id, $option));
 
 		return true;
+	}
+
+	public function _default_label($id, $option) {
+		return false;
 	}
 
 	/**

--- a/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
+++ b/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
@@ -23,7 +23,7 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 				)
 			),
 			'choices' => array(),
-			'hide_picker' => true,
+			'hide_picker' => false,
 			/**
 			 * Display separators between options
 			 */

--- a/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
+++ b/framework/includes/option-types/multi-picker/class-fw-option-type-multi-picker.php
@@ -65,6 +65,9 @@ class FW_Option_Type_Multi_Picker extends FW_Option_Type
 		return true;
 	}
 
+	/**
+	 * Hide label for each multi-picker by default
+	 */
 	public function _default_label($id, $option) {
 		return false;
 	}

--- a/framework/views/backend-option-design-customizer.php
+++ b/framework/views/backend-option-design-customizer.php
@@ -7,7 +7,9 @@
 
 {
 	if (!isset($option['label'])) {
-		$option['label'] = fw_id_to_title($id);
+		$option['label'] = fw()->backend->option_type($option['type'])->_default_label(
+			$id, $option
+		);
 	}
 
 	if (!isset($option['desc'])) {

--- a/framework/views/backend-option-design-default.php
+++ b/framework/views/backend-option-design-default.php
@@ -7,7 +7,9 @@
 
 {
 	if (!isset($option['label'])) {
-		$option['label'] = fw_id_to_title($id);
+		$option['label'] = fw()->backend->option_type($option['type'])->_default_label(
+			$id, $option
+		);
 	}
 
 	if (!isset($option['desc'])) {
@@ -133,6 +135,7 @@ try {
 		$desc_under_label = apply_filters('fw:backend-option-view:design-default:desc-under-label', false)
 	);
 }
+
 ?>
 <div class="<?php echo esc_attr($classes['option']) ?>" id="fw-backend-option-<?php echo esc_attr($data['id_prefix'] . $id) ?>">
 	<?php if ($option['label'] !== false): ?>


### PR DESCRIPTION
Introduces a `_default_label()` method for every option type and allows them to override it. By default this method uses [`fw_id_to_title()`](https://github.com/ThemeFuse/Unyson/blob/afc9da37c012023c990bd62d9857f55586d1a93e/framework/helpers/general.php#L1601-L1613) to prettify the `$id` of that particular option.