### PR TITLE
quick filtering from the main serialization loop

### DIFF
--- a/framework/static/js/fw-reactive-options-undefined-option.js
+++ b/framework/static/js/fw-reactive-options-undefined-option.js
@@ -159,6 +159,18 @@
 					'.fw-backend-options-virtual-context textarea'
 				)
 			)
+		).not(
+			jQuery(el).find(
+				'.fw-filter-from-serialization input'
+			).add(
+				jQuery(el).find(
+					'.fw-filter-from-serialization select'
+				)
+			).add(
+				jQuery(el).find(
+					'.fw-filter-from-serialization textarea'
+				)
+			)
 		);
 	}
 
@@ -232,9 +244,11 @@
 		}
 
 		function addPair(pair) {
-			if (!patterns.validate.test(pair.name)) return this;
+			if (! patterns.validate.test(pair.name)) return this;
+
 			var obj = makeObject(pair.name, encode(pair));
 			data = helper.extend(true, data, obj);
+
 			return this;
 		}
 


### PR DESCRIPTION
A hacky way of filtering fields from the serializer used for [default `.getValue()`](https://github.com/ThemeFuse/Unyson/blob/5b0dbb97413406bc6d4e815b5f43b619cf092124/framework/static/js/fw-reactive-options-undefined-option.js#L3-L6).