### PR TITLE
better reactivity for unique option type

### DIFF
--- a/framework/static/js/fw-reactive-options-simple-options.js
+++ b/framework/static/js/fw-reactive-options-simple-options.js
@@ -1,4 +1,4 @@
-(function ($) {
+(function($) {
 	var simpleInputs = [
 		'text',
 		'short-text',
@@ -8,94 +8,102 @@
 		'html',
 		'html-fixed',
 		'html-full',
-		'unique',
 		'select',
 		'short-select',
 		'gmap-key',
 		'slider',
-		'short-slider'
-	]
+		'short-slider',
+	];
 
-	simpleInputs.map(function (optionType) {
+	simpleInputs.map(function(optionType) {
 		fw.options.register(optionType, {
-			getValue: getValueForSimpleInput
+			getValue: getValueForSimpleInput,
 		});
 	});
 
-	function getValueForSimpleInput (optionDescriptor) {
+	function getValueForSimpleInput(optionDescriptor) {
 		return {
-			value: optionDescriptor.el.querySelector(
-				'input, textarea, select'
-			).value,
-			optionDescriptor: optionDescriptor
+			value: optionDescriptor.el.querySelector('input, textarea, select')
+				.value,
+			optionDescriptor: optionDescriptor,
 		};
 	}
 
+	fw.options.register('unique', {
+		getValue: function(optionDescriptor) {
+			var actualValue = optionDescriptor.el.querySelector(
+				'input, textarea, select'
+			).value;
+
+			return {
+				value: !!actualValue.trim() ? actualValue : fw.randomMD5(),
+				optionDescriptor: optionDescriptor,
+			};
+		},
+	});
+
 	fw.options.register('checkbox', {
-		getValue: function (optionDescriptor) {
+		getValue: function(optionDescriptor) {
 			return {
 				value: optionDescriptor.el.querySelector(
 					'input.fw-option-type-checkbox'
 				).checked,
-				optionDescriptor: optionDescriptor
+				optionDescriptor: optionDescriptor,
 			};
-		}
+		},
 	});
 
 	fw.options.register('checkboxes', {
-		getValue: function (optionDescriptor) {
-			var checkboxes = $(optionDescriptor.el).find(
-				'[type="checkbox"]'
-			).slice(1);
+		getValue: function(optionDescriptor) {
+			var checkboxes = $(optionDescriptor.el)
+				.find('[type="checkbox"]')
+				.slice(1);
 
 			var value = {};
 
-			checkboxes.toArray().map(function (el) {
+			checkboxes.toArray().map(function(el) {
 				value[$(el).attr('data-fw-checkbox-id')] = el.checked;
 			});
 
 			return {
 				value: value,
-				optionDescriptor: optionDescriptor
+				optionDescriptor: optionDescriptor,
 			};
-		}
+		},
 	});
 
 	fw.options.register('radio', {
-		getValue: function (optionDescriptor) {
+		getValue: function(optionDescriptor) {
 			return {
 				value: $(optionDescriptor.el).find('input:checked').val(),
-				optionDescriptor: optionDescriptor
+				optionDescriptor: optionDescriptor,
 			};
-		}
+		},
 	});
 
 	fw.options.register('select-multiple', {
-		getValue: function (optionDescriptor) {
+		getValue: function(optionDescriptor) {
 			return {
-				value: $(optionDescriptor.el.querySelector(
-					'select'
-				)).val(),
-				optionDescriptor: optionDescriptor
+				value: $(optionDescriptor.el.querySelector('select')).val(),
+				optionDescriptor: optionDescriptor,
 			};
-		}
+		},
 	});
 
 	fw.options.register('multi', {
-		getValue: function (optionDescriptor) {
-			var promise = $.Deferred()
+		getValue: function(optionDescriptor) {
+			var promise = $.Deferred();
 
 			fw.options
 				.getContextValue(optionDescriptor.el)
-				.then(function (result) {
+				.then(function(result) {
 					promise.resolve({
 						value: result.value,
-						optionDescriptor: optionDescriptor
+						optionDescriptor: optionDescriptor,
 					});
 				});
 
 			return promise;
-		}
-	})
-
+		},
+	});
 })(jQuery);


### PR DESCRIPTION
Now [`unique`](https://github.com/ThemeFuse/Unyson/blob/9ae8eb6958356b764ac317de5e19a48ccce2bbfd/framework/includes/option-types/simple.php#L1039-L1196) option type properly generates random IDs in frontend, when getting value, if one is not present already.