### PR TITLE
options argument for fw.options.fetchHtml

### DIFF
--- a/framework/static/js/fw-reactive-options.js
+++ b/framework/static/js/fw-reactive-options.js
@@ -153,8 +153,12 @@ fw.options = (function($, currentFwOptions) {
 			: $(el).closest('.fw-backend-option-descriptor')[0];
 	}
 
-	function fetchHtml(options, values) {
+	function fetchHtml(options, values, options) {
 		var promise = $.Deferred();
+
+		if (!options) options = {};
+
+		options = _.extend({ name_prefix: 'fw_edit_options_modal' }, options);
 
 		var cacheId = fetchHtmlGetCacheId(options, values);
 
@@ -173,8 +177,8 @@ fw.options = (function($, currentFwOptions) {
 					typeof values == 'undefined' ? {} : values
 				),
 				data: {
-					name_prefix: 'fw_edit_options_modal',
-					id_prefix: 'fw-edit-options-modal-',
+					name_prefix: options.name_prefix,
+					id_prefix: options.name_prefix.replace(/_/g, '-') + '-',
 				},
 			},
 			dataType: 'json',

--- a/framework/static/js/fw-reactive-options.js
+++ b/framework/static/js/fw-reactive-options.js
@@ -153,12 +153,12 @@ fw.options = (function($, currentFwOptions) {
 			: $(el).closest('.fw-backend-option-descriptor')[0];
 	}
 
-	function fetchHtml(options, values, options) {
+	function fetchHtml(options, values, settings) {
 		var promise = $.Deferred();
 
-		if (!options) options = {};
+		if (!settings) settings = {};
 
-		options = _.extend({ name_prefix: 'fw_edit_options_modal' }, options);
+		settings = _.extend({ name_prefix: 'fw_edit_options_modal' }, settings);
 
 		var cacheId = fetchHtmlGetCacheId(options, values);
 
@@ -177,8 +177,8 @@ fw.options = (function($, currentFwOptions) {
 					typeof values == 'undefined' ? {} : values
 				),
 				data: {
-					name_prefix: options.name_prefix,
-					id_prefix: options.name_prefix.replace(/_/g, '-') + '-',
+					name_prefix: settings.name_prefix,
+					id_prefix: settings.name_prefix.replace(/_/g, '-') + '-',
 				},
 			},
 			dataType: 'json',


### PR DESCRIPTION
It allows to configure `name_prefix` for the generated options.
Currently, the `id_prefix` is auto generated from the `name_prefix`
option and it may change in the future.

```js
fw.options.fetchHtml({
    a: {
        type: 'text'
    }
}, {}, { name_prefix: 'my_name_prefix' }).then(function (html) {
    console.log(html);
});
```