### PR TITLE
Introduce fw.options.getActualValues helper

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -1262,10 +1262,12 @@ final class _FW_Component_Backend {
 				$values = json_decode( FW_Request::POST( 'values' ), true );
 			}
 
-			if ( ! $values ) {
-				wp_send_json_error(array(
-					'message' => 'Wrong values'
-				));
+			if (! is_array($values)) {
+				if ( ! $values ) {
+					wp_send_json_error(array(
+						'message' => 'Wrong values'
+					));
+				}
 			}
 		}
 

--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -189,6 +189,7 @@ final class _FW_Component_Backend {
 			{
 				add_action('wp_ajax_fw_backend_options_render', array($this, '_action_ajax_options_render'));
 				add_action('wp_ajax_fw_backend_options_get_values', array($this, '_action_ajax_options_get_values'));
+				add_action('wp_ajax_fw_backend_options_get_values_json', array($this, '_action_ajax_options_get_values_json'));
 			}
 		}
 
@@ -1212,6 +1213,66 @@ final class _FW_Component_Backend {
 			'values' => fw_get_options_values_from_input(
 				$options,
 				FW_Request::POST( fw_html_attr_name_to_array_multi_key( $name_prefix ), array() )
+			)
+		) );
+	}
+
+	/**
+	 * Get options values from html generated with 'fw_backend_options_render' ajax action
+	 *
+	 * POST vars:
+	 * - options: '[{option_id: {...}}, {option_id: {...}}, ...]' // Required // String JSON
+	 * - values: {option_id: {...}}
+	 *
+	 * Tip: Inside form html, add: <input type="hidden" name="options" value="[...json...]">
+	 */
+	public function _action_ajax_options_get_values_json() {
+		// options
+		{
+			if ( ! isset( $_POST['options'] ) ) {
+				wp_send_json_error( array(
+					'message' => 'No options'
+				) );
+			}
+
+			$options = FW_Request::POST( 'options' );
+
+			if (is_string( $options )) {
+				$options = json_decode( FW_Request::POST( 'options' ), true );
+			}
+
+			if ( ! $options ) {
+				wp_send_json_error( array(
+					'message' => 'Wrong options'
+				) );
+			}
+		}
+
+		// values
+		{
+			if ( ! isset( $_POST['values'] ) ) {
+				wp_send_json_error( array(
+					'message' => 'No values'
+				) );
+			}
+
+			$values = FW_Request::POST( 'values' );
+
+			if (is_string( $values )) {
+				$values = json_decode( FW_Request::POST( 'values' ), true );
+			}
+
+			if ( ! $values ) {
+				wp_send_json_error(array(
+					'message' => 'Wrong values'
+				));
+			}
+		}
+
+		wp_send_json_success( array(
+			'values' => fw_get_options_values_from_input(
+				$options,
+				$values
 			)
 		) );
 	}


### PR DESCRIPTION
There was a [`fw.getValuesFromServer`](https://github.com/ThemeFuse/Unyson/blob/d7ab4a1d7211738621ba0358dc76d7cf5eba1b8b/framework/static/js/fw.js#L1069-L1093) but it worked only with form data for passing values and that was very cumbersome.

The new `fw.options.getActualValues` works simply with JavaScript objects, which is very convenient and simple.

It also is a possible fix for #2494, if we get to use that for saving Theme Settings Ajax Forms. It needs a lot of testing to make sure it works fine.