### PR TITLE
Added fw_print alias

### DIFF
--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -421,6 +421,17 @@ function fw_print( $value ) {
 }
 
 /**
+ * Alias for fw_print
+ *
+ * @see fw_print()
+ */
+if ( ! function_exists( 'debug' ) ) {
+	function debug() {
+		call_user_func_array( 'fw_print', func_get_args() );
+	}
+}
+
+/**
  * Generate html tag
  *
  * @param string $tag Tag name


### PR DESCRIPTION
Added an alias for `fw_print` named `debug` is a common function name for other frameworks like **Simfony**.