### PR TITLE
Scroll to top on tab change

### DIFF
--- a/framework/static/js/backend-options.js
+++ b/framework/static/js/backend-options.js
@@ -122,6 +122,7 @@ jQuery(document).ready(function($){
 					},
 					activate: function (event, ui) {
 						initTab(ui.newPanel);
+						ui.newPanel.closest('.fw-options-tabs-contents')[0].scrollTop = 0
 					}
 				});
 
@@ -135,7 +136,11 @@ jQuery(document).ready(function($){
 						}
 					});
 			} else {
-				$tabs.tabs();
+				$tabs.tabs({
+					activate: function (event, ui) {
+						ui.newPanel.closest('.fw-options-tabs-contents')[0].scrollTop = 0
+					}
+				});
 			}
 
 			$tabs.each(function () {


### PR DESCRIPTION
[Video](https://cl.ly/lq7F)

On very long tabs, it was a bit confusing for users to be left on the bottom after a tab switch. This pull request fixes that behavior.