### PR TITLE
fix popup option type reactivity

### DIFF
--- a/framework/includes/option-types/popup/static/js/popup.js
+++ b/framework/includes/option-types/popup/static/js/popup.js
@@ -104,7 +104,7 @@
 		getValue: function (optionDescriptor) {
 			return {
 				value: JSON.parse(
-					$(optionDescriptor.el).find('[type="hidden"]').val()
+					$(optionDescriptor.el).find('[type="hidden"]').val() || '""'
 				),
 
 				optionDescriptor: optionDescriptor


### PR DESCRIPTION
Incorrect input for the `JSON.parse()` function is sometimes provided.