### PR TITLE
Fixed fw_current_url() for subdirectories

### DIFF
--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -1332,8 +1332,18 @@ function fw_current_url() {
 		} else {
 			$url = get_option( 'home' );
 		}
-		$url .= fw_akg( 'REQUEST_URI', $_SERVER, '/' );
-		$url = set_url_scheme( $url ); // https fix
+
+		//Remove the "//" before the domain name
+		$url = ltrim( fw_get_url_without_scheme( $url ), '/' );
+
+		//Remove the ulr subdirectory in case it has one
+		$split = explode( '/', $url );
+
+		//Remove end slash
+		$url = rtrim( $split[0], '/' );
+
+		$url .= '/' . ltrim( fw_akg( 'REQUEST_URI', $_SERVER, '' ), '/' );
+		$url = set_url_scheme( '//' . $url ); // https fix
 	}
 
 	return $url;


### PR DESCRIPTION
### Problem
`fw_current_url` uses the `get_option( 'home' )` function to get the current wordpress url. If current wordpress installation is in a sub-directory, the url will be `http://mysite.com/wp-install`. In the second part of the `fw_current_url` is used the `$_SERVER['REQUEST_URI']` that is adding the `/wp-sintall` sub-directory too. In the end function got this: `http://mysite.com/wp-install/wp-install/?test=test`

### Solution
The solution is to remove the subdirectory part form the `get_option( 'home' )` as it will be added by `$_SERVER['REQUEST_URI']`

### Fixes https://github.com/ThemeFuse/Unyson/issues/2703