### PR TITLE
Fix rgba slider not going all the way to zero

### DIFF
--- a/framework/includes/option-types/rgba-color-picker/static/js/scripts.js
+++ b/framework/includes/option-types/rgba-color-picker/static/js/scripts.js
@@ -8,7 +8,7 @@ jQuery(function($){
   };
   Color.prototype.toRgba = function (a) {
     var rgb = this.toRgb();
-    rgb['a'] = (typeof a === 'undefined') ? 1 : 0;
+    rgb['a'] = (typeof a === 'undefined') ? 1 : a;
     return rgb;
   }
   Color.prototype.toRgbaCSS = function (a) {


### PR DESCRIPTION
'0' is falsy, so slider would just jump back to '1'. This fixes that.
closes #2781 