### PR TITLE
post ids to integer multi-select option type & post_type define #2862

### DIFF
--- a/framework/includes/option-types/multi-select/class-fw-option-type-multi-select.php
+++ b/framework/includes/option-types/multi-select/class-fw-option-type-multi-select.php
@@ -121,8 +121,14 @@ if ( ! class_exists( 'FW_Option_Type_Multi_Select' ) ):
 				return array();
 			}
 
+			$ids = array_map( 'intval', $ids );
+
+			if (! get_post_type($ids[0]) ) {
+				return;
+			}
+
 			$query = new WP_Query( array(
-				'post_type'      => 'any',
+				'post_type'      => get_post_type($ids[0]),
 				'post__in'       => $ids,
 				'posts_per_page' => $limit,
 				'fields'         => 'ids'


### PR DESCRIPTION
changed post_ids to integer as @ViorelEremia did and then 'post_type' define from post ids. That would be great if we could directly use from 'source' => 'custom_post_type_name'. But, I don't know which function to get 'source' value.