### PR TITLE
refactor($iconv2): Fix modal HTML initialization

### DIFF
--- a/framework/includes/option-types/icon-v2/static/js/icon-picker-v2.js
+++ b/framework/includes/option-types/icon-v2/static/js/icon-picker-v2.js
@@ -544,7 +544,6 @@
 		},
 
 		getTabsHtml: function() {
-
 			return wp.template('fw-icon-v2-tabs')({
 				icons_library_html: this.getLibraryHtml(),
 				favorites_list_html: this.getFavoritesHtml(),
@@ -552,11 +551,9 @@
 				current_state: this.result,
 				favorites: this.currentFavorites,
 			});
-
 		},
 
 		getLibraryHtml: function() {
-
 			var packs = _.values(this.getIconsData());
 			var pack_to_select = [ _.first(packs) ];
 
@@ -591,7 +588,9 @@
 		},
 	});
 
-	fwOptionTypeIconV2Instance = new fwOptionTypeIconV2Picker();
+	$(function () {
+		fwOptionTypeIconV2Instance = new fwOptionTypeIconV2Picker();
+	});
 
 	Selectize.define('hidden_textfield', function(options) {
 		var self = this;

--- a/framework/includes/option-types/icon-v2/views/templates.php
+++ b/framework/includes/option-types/icon-v2/views/templates.php
@@ -74,7 +74,7 @@ $tabs = fw()->backend->render_options(
 		</select>
 	<# } #>
 
-	<input 
+	<input
 		type="text"
 		placeholder="<?php echo __('Search Icon', 'fw'); ?>"
 		class="fw-option fw-option-type-text">
@@ -185,7 +185,7 @@ $tabs = fw()->backend->render_options(
 	</div>
 
 <# } else { #>
-	
+
 	<div class="fw-icon-v2-library-pack-wrapper">
 		<ul class="fw-icon-v2-library-pack">
 
@@ -222,7 +222,7 @@ $tabs = fw()->backend->render_options(
 			<li class="fw-ghost-item"></li>
 			<li class="fw-ghost-item"></li>
 			<li class="fw-ghost-item"></li>
-			
+
 		</ul>
 	</div>
 
@@ -267,7 +267,7 @@ $tabs = fw()->backend->render_options(
 			<li class="fw-ghost-item"></li>
 			<li class="fw-ghost-item"></li>
 			<li class="fw-ghost-item"></li>
-			
+
 		</ul>
 	<# } #>
 


### PR DESCRIPTION
Sometimes the templates are missing from the DOM at the initialization time. This fixes that. Specifically, it initializes the `icon-v2` instance by waiting on the `jQuery.ready` event.