### PR TITLE
feat($reactivity): Implement reactivity for radio-text

### DIFF
--- a/framework/includes/option-types/radio-text/class-fw-option-type-radio-text.php
+++ b/framework/includes/option-types/radio-text/class-fw-option-type-radio-text.php
@@ -11,6 +11,10 @@ class FW_Option_Type_Radio_Text extends FW_Option_Type
 		return 'radio-text';
 	}
 
+	public function _get_data_for_js($id, $option, $data = array()) {
+		return false;
+	}
+
 	/**
 	 * @internal
 	 */

--- a/framework/includes/option-types/radio-text/static/js/scripts.js
+++ b/framework/includes/option-types/radio-text/static/js/scripts.js
@@ -1,19 +1,42 @@
-jQuery(function($){
+jQuery(function($) {
 	var optionTypeClass = '.fw-option-type-radio-text';
-	var customRadioSelector = '.predefined .fw-option-type-radio > div:last-child input[type="radio"]';
+	var customRadioSelector =
+		'.predefined .fw-option-type-radio > div:last-child input[type="radio"]';
 
-	fwEvents.on('fw:options:init', function (data) {
-		var $options = data.$elements.find(optionTypeClass +':not(.initialized)');
+	fwEvents.on('fw:options:init', function(data) {
+		var $options = data.$elements.find(
+			optionTypeClass + ':not(.initialized)'
+		);
 
-		$options.find('.fw-option-type-text').on('focus', function () {
+		$options.find('.fw-option-type-text').on('focus', function() {
 			// check "custom" radio box
-			$(this).closest(optionTypeClass).find(customRadioSelector).prop('checked', true);
+			$(this)
+				.closest(optionTypeClass)
+				.find(customRadioSelector)
+				.prop('checked', true);
 		});
 
-		$options.find(customRadioSelector).on('focus', function () {
+		$options.find(customRadioSelector).on('focus', function() {
 			$(this).closest(optionTypeClass).find('.custom input').focus();
 		});
 
 		$options.addClass('initialized');
+	});
+
+	fw.options.register('radio-text', {
+		getValue: function(optionDescriptor) {
+			var checked = $(optionDescriptor.el).find('input:checked');
+
+			var value = checked.val();
+
+			if (checked.closest('div').is(':last-child')) {
+				value = $(optionDescriptor.el).find('[type="text"]').val();
+			}
+
+			return {
+				value: value,
+				optionDescriptor: optionDescriptor,
+			};
+		},
 	});
 });


### PR DESCRIPTION
This pull request implements reactivity for the [`radio-text`](https://github.com/ThemeFuse/Unyson/blob/74b0976e627335687bf594ca319f49686492d4d6/framework/includes/option-types/radio-text/class-fw-option-type-radio-text.php#L1) option type.