### PR TITLE
fix($option-types): makes the db value of checkboxes more robust

### DIFF
--- a/framework/includes/option-types/simple.php
+++ b/framework/includes/option-types/simple.php
@@ -562,10 +562,15 @@ class FW_Option_Type_Checkboxes extends FW_Option_Type {
 
 			foreach ($option['choices'] as $choice => $choice_value){
 				if (isset($input_value[$choice]) && $input_value[$choice] ) {
+					// Handle boolean values that got lost into the universe
+					// and somehow become strings by the miracle of
+					// PHP's $_POST parsing
 					$value[$choice] = is_string(
 						$input_value[$choice]
 					) ? $input_value[$choice] === 'true' : true;
 				} else {
+					// If the value's missing from the input it is falsy,
+					// for sure
 					$value[$choice] = false;
 				}
 			}

--- a/framework/includes/option-types/simple.php
+++ b/framework/includes/option-types/simple.php
@@ -560,16 +560,14 @@ class FW_Option_Type_Checkboxes extends FW_Option_Type {
 		if ( is_array( $input_value ) ) {
 			$value = array();
 
-			foreach ( $input_value as $choice => $val ) {
-				if ( $val === '' ) {
-					continue;
+			foreach ($option['choices'] as $choice => $choice_value){
+				if (isset($input_value[$choice]) && $input_value[$choice] ) {
+					$value[$choice] = is_string(
+						$input_value[$choice]
+					) ? $input_value[$choice] === 'true' : true;
+				} else {
+					$value[$choice] = false;
 				}
-
-				if ( ! isset( $option['choices'][ $choice ] ) ) {
-					continue;
-				}
-
-				$value[ $choice ] = true;
 			}
 		} else {
 			$value = $option['value'];


### PR DESCRIPTION
First of all, this change will make sure that each key from choices will be present in the final
value. This is very important and helps a lot by avoiding useless checks in templates that consume
the values.

One example would be that you'll need to do something like that in your `view.php`'s

```php
if (isset($atts['checkboxes_value']['first']) && $atts['checkboxes_value']['first']) {
  // Do action
}
```

With that change, you could skip the `isset(...)` call.