### PR TITLE
feat($designs): introduce a way for option types to force a design

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -13,7 +13,9 @@ final class _FW_Component_Backend {
 	/** @var FW_Settings_Form */
 	private $settings_form;
 
-	private $available_render_designs = array( 'default', 'taxonomy', 'customizer' );
+	private $available_render_designs = array(
+		'default', 'taxonomy', 'customizer', 'empty'
+	);
 
 	private $default_render_design = 'default';
 
@@ -1487,8 +1489,16 @@ final class _FW_Component_Backend {
 	 * @return string
 	 */
 	public function render_option( $id, $option, $data = array(), $design = null ) {
+		$maybe_forced_design = fw()->backend->option_type(
+			$option['type']
+		)->get_forced_render_design();
+
 		if (empty($design)) {
 			$design = $this->default_render_design;
+		}
+
+		if ($maybe_forced_design) {
+			$design = $maybe_forced_design;
 		}
 
 		if (

--- a/framework/core/extends/class-fw-option-type.php
+++ b/framework/core/extends/class-fw-option-type.php
@@ -78,6 +78,18 @@ abstract class FW_Option_Type
 	}
 
 	/**
+	 * An option type can decide which design to use by default when rendering
+	 * itself.
+	 *
+	 * @return
+	 *   null - will use whatever is passed based on the context
+	 *   string - will use that particular design
+	 */
+	public function get_forced_render_design() {
+		return null;
+	}
+
+	/**
 	 * Prevent execute enqueue multiple times
 	 * @var bool
 	 */

--- a/framework/views/backend-option-design-empty.php
+++ b/framework/views/backend-option-design-empty.php
@@ -1,0 +1,3 @@
+<?php
+
+echo fw()->backend->option_type($option['type'])->render($id, $option, $data);


### PR DESCRIPTION
Also, will create and allow the usage of a brand new empty design.

You can declare a specialized method in your option type for doing so:

```php
// null to use whatever design, based on the context
// force a specific one
public function get_forced_render_design() {
  return 'empty';
}
```