### PR TITLE
Properly enqueue agressive coder for wp-editor

### DIFF
--- a/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
+++ b/framework/includes/option-types/wp-editor/class-fw-option-type-wp-editor.php
@@ -95,6 +95,7 @@ class FW_Option_Type_Wp_Editor extends FW_Option_Type {
 		if ( ! wp_script_is( 'editor' ) ) {
 			wp_enqueue_script( 'editor' );
 			wp_enqueue_script( 'quicktags' );
+			wp_enqueue_script('fw-ext-shortcodes-editor-integration');
 
 			if ( ! class_exists( '_WP_Editors', false ) ) {
 				require( ABSPATH . WPINC . '/class-wp-editor.php' );


### PR DESCRIPTION
Fixes #3061 

The cause: https://github.com/ThemeFuse/Unyson/commit/a36762d8ecbfa0ffd1cf8d772fdabbc97cfe1e7a

cc. @danyj @ViorelEremia 