### PR TITLE
feat($manager): introduce a filter that allow disabling unyson button

### DIFF
--- a/framework/core/components/extensions/manager/class--fw-extensions-manager.php
+++ b/framework/core/components/extensions/manager/class--fw-extensions-manager.php
@@ -746,6 +746,10 @@ final class _FW_Extensions_Manager
 			}
 		}
 
+		if (! apply_filters('fw_backend_enable_custom_extensions_menu', true)) {
+			return;
+		}
+
 		/**
 		 * Use this action if you what to add the extensions page in a custom place in menu
 		 * Usage example http://pastebin.com/2iWVRPAU


### PR DESCRIPTION
```php
add_filter(
    // or __return_true, maybe also include a custom callback for even more complex logic
	'fw_backend_enable_custom_extensions_menu', '__return_false'
);
```