### PR TITLE
feat($icon-v2): respect apply_root_class option for icon packs

### DIFF
--- a/framework/includes/option-types/icon-v2/views/templates.php
+++ b/framework/includes/option-types/icon-v2/views/templates.php
@@ -236,7 +236,7 @@ $tabs = fw()->backend->render_options(
 		<ul class="fw-icon-v2-library-pack">
 
 		<# _.each(data.icons, function (icon) { #>
-			<# var iconClass = data.css_class_prefix ? data.css_class_prefix + ' ' + icon : icon; #>
+			<# var iconClass = (data.css_class_prefix && data.apply_root_class) ? data.css_class_prefix + ' ' + icon : icon; #>
 			<# var selectedClass = data.current_state['icon-class'] === iconClass ? 'selected' : ''; #>
 			<# var favoriteClass = _.contains(data.favorites, iconClass) ? 'fw-icon-v2-favorite' : '' #>
 


### PR DESCRIPTION
Fixes #2659 

This PR will implement `apply_root_class` for `icon-v2` packs. Setting this value to `false` will actually affect DB value for the option type, be careful.