### PR TITLE
feat($filters): allow filters to intercept saved & rendered values

### DIFF
--- a/framework/core/components/backend.php
+++ b/framework/core/components/backend.php
@@ -1153,7 +1153,7 @@ final class _FW_Component_Backend {
 				$values = array();
 			}
 
-			$values = array_intersect_key($values, fw_extract_only_options($options));
+			$values = fw_get_options_values_from_input($options, $values);
 		}
 
 		// data
@@ -1381,7 +1381,19 @@ final class _FW_Component_Backend {
 					foreach ( $collected_type_options as $id => &$_option ) {
 						$data = $options_data; // do not change directly to not affect next loops
 
-						$data['value'] = isset( $values[ $id ] ) ? $values[ $id ] : null;
+						$maybe_future_value = apply_filters(
+							'fw:render_options:option_value',
+							null,
+							$values,
+							$_option,
+							$id
+						);
+
+						if (! $maybe_future_value) {
+							$maybe_future_value = isset( $values[ $id ] ) ? $values[ $id ] : null;
+						}
+
+						$data['value'] = $maybe_future_value;
 
 						$html .= $this->render_option(
 							$id,

--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -1155,6 +1155,24 @@ function fw_get_options_values_from_input( array $options, $input_array = null )
 
 	$values = array();
 
+	$maybe_new_values = apply_filters(
+		'fw:get_options_values_from_input:before',
+		null,
+		$options, $input_array
+	);
+
+	if ($maybe_new_values) {
+		return $maybe_new_values;
+	}
+
+	$first_option = array_keys(fw_extract_only_options( $options ));
+	$first_option = $extracted[$first_option[0]];
+
+	if ($first_option['type'] === 'ct-options-panel') {
+		require "/Users/andreiglingeanu/.composer/vendor/bin/psysh";
+		\Psy\Shell::debug(get_defined_vars());
+	}
+
 	foreach ( fw_extract_only_options( $options ) as $id => $option ) {
 		$values[ $id ] = fw()->backend->option_type( $option['type'] )->get_value_from_input(
 			$option,

--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -1165,14 +1165,6 @@ function fw_get_options_values_from_input( array $options, $input_array = null )
 		return $maybe_new_values;
 	}
 
-	$first_option = array_keys(fw_extract_only_options( $options ));
-	$first_option = $extracted[$first_option[0]];
-
-	if ($first_option['type'] === 'ct-options-panel') {
-		require "/Users/andreiglingeanu/.composer/vendor/bin/psysh";
-		\Psy\Shell::debug(get_defined_vars());
-	}
-
 	foreach ( fw_extract_only_options( $options ) as $id => $option ) {
 		$values[ $id ] = fw()->backend->option_type( $option['type'] )->get_value_from_input(
 			$option,

--- a/framework/static/js/fw.js
+++ b/framework/static/js/fw.js
@@ -1287,6 +1287,8 @@ fw.getValuesFromServer = function (data) {
 		initialize: function () {
 			fw.Modal.prototype.initialize.apply(this, arguments);
 
+			fwEvents.trigger('fw:options-modal:after-initialize', {modal: this});
+
 			// Forward events to fwEvents
 			{
 				/** @since 2.6.14 */


### PR DESCRIPTION
Introduces two small filters:

- `fw:render_options:option_value`
- `fw:get_options_values_from_input:before`