### PR TITLE
chore($fw.Modal): remove focus hack which used to prevent jumping

### DIFF
--- a/framework/static/js/fw.js
+++ b/framework/static/js/fw.js
@@ -749,8 +749,6 @@ fw.getQueryString = function(name) {
 				uploader: false
 			});
 
-			patchMediaFramesModalToDoTheFocusCorrectly( this.frame );
-
 			var modal = this;
 
 			this.frame.once('ready', function(){
@@ -1007,65 +1005,6 @@ fw.getQueryString = function(name) {
 			$frame.css('overflow-y', 'hidden');
 		}
 	});
-
-	// https://github.com/WordPress/WordPress/blob/4ca4ff999aba05892c05d26cddf3af540f47b93b/wp-includes/js/media-views.js#L6800
-	// When you execute frame.modal.open() - the modal tries to switch focus
-	// to its $el. Actually, this switches the scrollTop property for window.
-	//
-	// In order to prevent that we'll have to monkey patch the frame.modal.open
-	// method and do the focus properly - that's what this function does
-	function patchMediaFramesModalToDoTheFocusCorrectly (frame) {
-		if (! frame.modal) return;
-
-		frame.modal.open = function () {
-			var $el = this.$el,
-				options = this.options,
-				mceEditor;
-
-			if ( $el.is(':visible') ) {
-				return this;
-			}
-
-			this.clickedOpenerEl = document.activeElement;
-
-			if ( ! this.views.attached ) {
-				this.attach();
-			}
-
-			// If the `freeze` option is set, record the window's scroll position.
-			if ( options.freeze ) {
-				this._freeze = {
-					scrollTop: jQuery( window ).scrollTop()
-				};
-			}
-
-			// Disable page scrolling.
-			jQuery( 'body' ).addClass( 'modal-open' );
-
-			$el.show();
-
-			// Try to close the onscreen keyboard
-			if ( 'ontouchend' in document ) {
-				if ( ( mceEditor = window.tinymce && window.tinymce.activeEditor )  && ! mceEditor.isHidden() && mceEditor.iframeElement ) {
-					mceEditor.iframeElement.focus();
-					mceEditor.iframeElement.blur();
-
-					setTimeout( function() {
-						mceEditor.iframeElement.blur();
-					}, 100 );
-				}
-			}
-
-			// this part is changed from the original method
-			// this.$el.focus();
-			// http://stackoverflow.com/a/11676673/3220977
-			var initialX = window.scrollX, initialY = window.scrollY;
-			this.$el.focus();
-			window.scrollTo(initialX, initialY);
-
-			return this.propagate('open');
-		}
-	}
 })();
 
 /**


### PR DESCRIPTION
Finally fix #2399. https://core.trac.wordpress.org/ticket/39859 got merged in `4.9.3` in core, everything works now without any hacks from our side!

More context for the issue: #2388