### PR TITLE
fix($ie): function call with trailing comma

### DIFF
--- a/framework/static/js/fw-reactive-options-registry.js
+++ b/framework/static/js/fw-reactive-options-registry.js
@@ -232,7 +232,7 @@ fw.options = (function ($, currentFwOptions) {
 		allOptionTypes[type] = jQuery.extend(
 			{}, defaultHintObject(),
 			(allOptionTypes[type] || {}),
-			hintObject || {},
+			hintObject || {}
 		);
 	}
 


### PR DESCRIPTION
This doesn't work in IE 10