### PR TITLE
Fixed label multiline in "Typography v2"

### DIFF
--- a/framework/includes/option-types/typography-v2/static/css/styles.css
+++ b/framework/includes/option-types/typography-v2/static/css/styles.css
@@ -301,4 +301,7 @@ color:      fw-col-sm-2 = 16.66666667%
 	padding-bottom: 10px;
 	font-style: italic;
 	color: #666;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }


### PR DESCRIPTION
In some languages, the height of the line with the elements jumps.

![_012](https://user-images.githubusercontent.com/2736539/37902995-f6741ca0-30fe-11e8-9cd7-46d62bbc9f94.png)
