### PR TITLE
Add prefix value for "unique"

### DIFF
--- a/framework/includes/option-types/simple.php
+++ b/framework/includes/option-types/simple.php
@@ -1055,6 +1055,7 @@ class FW_Option_Type_Unique extends FW_Option_Type {
 		return array(
 			'value' => '',
 			'length' => 0, // Limit id length
+			'prefix' => '', // Prefix for ID
 		);
 	}
 
@@ -1076,9 +1077,9 @@ class FW_Option_Type_Unique extends FW_Option_Type {
 	 * @param null|int $length_limit
 	 * @return string
 	 */
-	protected function generate_id($length_limit = null)
+	protected function generate_id($length_limit = null, $prefix = '')
 	{
-		$id = fw_rand_md5();
+		$id = $prefix . fw_rand_md5();
 
 		if ($length_limit) {
 			$id = substr($id, 0, (int)$length_limit);
@@ -1124,13 +1125,13 @@ class FW_Option_Type_Unique extends FW_Option_Type {
 	protected function _get_value_from_input($option, $input_value) {
 
 		if (is_null($input_value)) {
-			$id = empty($option['value']) ? $this->generate_id($option['length']) : $option['value'];
+			$id = empty($option['value']) ? $this->generate_id($option['length'], $option['prefix']) : $option['value'];
 		} else {
 			$id = $input_value;
 		}
 
 		if (empty($id) || !is_string($id)) {
-			$id = $this->generate_id($option['length']);
+			$id = $this->generate_id($option['length'], $option['prefix']);
 		}
 
 		/**
@@ -1158,7 +1159,7 @@ class FW_Option_Type_Unique extends FW_Option_Type {
 			}
 
 			while ( isset( $ids[ $post_id ][ $id ] ) ) {
-				$id = $this->generate_id( $option['length'] );
+				$id = $this->generate_id( $option['length'], $option['prefix'] );
 			}
 
 			$ids[ $post_id ][ $id ] = true;


### PR DESCRIPTION
Useful opportunity to work with these IDs. For example, if a direct transfer of an ID with a number at the beginning to SCSS - the layout may break (due to incorrect recognition of such ID).
It is also useful for direct transmission of ID blocks/sections. Without the need to add prefixes in several places.