### PR TITLE
Update class-fw-session.php

### DIFF
--- a/framework/helpers/class-fw-session.php
+++ b/framework/helpers/class-fw-session.php
@@ -10,7 +10,9 @@
 class FW_Session {
 	private static function start_session() {
 		if ( apply_filters( 'fw_use_sessions', true ) && ! session_id() ) {
-			session_start();
+			session_start([
+    'read_and_close' => true, // Closing session to avoid loopback error.
+]);
 		}
 	}
 
@@ -22,17 +24,20 @@ class FW_Session {
 		self::start_session();
 
 		return fw_akg( $key, $_SESSION, $default_value );
+		session_write_close();
 	}
 
 	public static function set( $key, $value ) {
 		self::start_session();
 
 		fw_aks( $key, $value, $_SESSION );
+		session_write_close(); 
 	}
 
 	public static function del( $key ) {
 		self::start_session();
 
 		fw_aku( $key, $_SESSION );
+		session_write_close(); 
 	}
 }


### PR DESCRIPTION
PHP sessions created with session_start() function may cause issues with REST API and loopback requests due to cURL error 28. According to recommendations of WordPress core team active PHP session should be closed before making any HTTP requests