### PR TITLE
fix incomplete result of category population in multiselect option type

### DIFF
--- a/framework/includes/option-types/multi-select/class-fw-option-type-multi-select.php
+++ b/framework/includes/option-types/multi-select/class-fw-option-type-multi-select.php
@@ -156,7 +156,7 @@ if ( ! class_exists( 'FW_Option_Type_Multi_Select' ) ):
 
 			$sql = "SELECT terms.term_id"
 			       . " FROM $wpdb->terms AS terms, $wpdb->term_taxonomy AS taxonomies"
-			       . " WHERE terms.term_id = taxonomies.term_id AND taxonomies.term_id = taxonomies.term_taxonomy_id";
+			       . " WHERE terms.term_id = taxonomies.term_id";
 
 			{
 				$prepare = array();


### PR DESCRIPTION
incomplete response when population set to category in multi-select option type, because in WordPress term_taxonomy table term_id and term_taxonomy_id is not always equal.