### PR TITLE
Fix PHP8 errors

### DIFF
--- a/framework/core/extends/class-fw-extension.php
+++ b/framework/core/extends/class-fw-extension.php
@@ -106,7 +106,7 @@ abstract class FW_Extension
 
 		if (!$full_path) {
 			trigger_error('Extension view not found: '. $name, E_USER_WARNING);
-			return;
+			return '';
 		}
 
 		return fw_render_view($full_path, $view_variables, $return);
@@ -384,7 +384,7 @@ abstract class FW_Extension
 	 * @param string|null $option_id
 	 * @param mixed $value
 	 */
-	final public function set_db_settings_option( $option_id = null, $value ) {
+	final public function set_db_settings_option( $option_id = null, $value = '' ) {
 		fw_set_db_ext_settings_option( $this->get_name(), $option_id, $value );
 	}
 
@@ -407,7 +407,7 @@ abstract class FW_Extension
 	 * @param string|null $multi_key The key of the data you want to set. null - all data
 	 * @param mixed $value
 	 */
-	final public function set_db_data( $multi_key = null, $value ) {
+	final public function set_db_data( $multi_key = null, $value = '' ) {
 		fw_set_db_extension_data( $this->get_name(), $multi_key, $value );
 	}
 

--- a/framework/helpers/class-fw-db-options-model.php
+++ b/framework/helpers/class-fw-db-options-model.php
@@ -242,7 +242,7 @@ abstract class FW_Db_Options_Model {
 		}
 	}
 
-	final public function set( $item_id = null, $option_id = null, $value, array $extra_data = array() ) {
+	final public function set( $item_id = null, $option_id = null, $value = '', array $extra_data = array() ) {
 		FW_Cache::del($cache_key_values = $this->get_cache_key('values', $item_id, $extra_data));
 		FW_Cache::del($cache_key_values_processed = $this->get_cache_key('values:processed', $item_id, $extra_data));
 

--- a/framework/helpers/class-fw-request.php
+++ b/framework/helpers/class-fw-request.php
@@ -29,7 +29,7 @@ class FW_Request
 {
 	protected static function prepare_key($key)
 	{
-		return (is_string($key) ? addslashes($key) : $key);
+		return $key;
 	}
 
 	protected static function get_set_key($multikey = null, $set_value = null, &$value = '')

--- a/framework/helpers/class-fw-request.php
+++ b/framework/helpers/class-fw-request.php
@@ -29,10 +29,10 @@ class FW_Request
 {
 	protected static function prepare_key($key)
 	{
-		return (get_magic_quotes_gpc() && is_string($key) ? addslashes($key) : $key);
+		return (is_string($key) ? addslashes($key) : $key);
 	}
 
-	protected static function get_set_key($multikey = null, $set_value = null, &$value)
+	protected static function get_set_key($multikey = null, $set_value = null, &$value = '')
 	{
 		$multikey = self::prepare_key($multikey);
 

--- a/framework/helpers/class-fw-wp-option.php
+++ b/framework/helpers/class-fw-wp-option.php
@@ -21,7 +21,7 @@ class FW_WP_Option
 			_doing_it_wrong(__FUNCTION__, '$get_original_value parameter was removed', 'Unyson 2.5.8');
 		}
 
-		$value = get_option($option_name, null);
+		$value = get_option($option_name = '', null);
 
 		if (empty($specific_multi_key) && $specific_multi_key !== '0') {
 			return is_null($value) ? fw_call( $default_value ) : $value;
@@ -36,7 +36,7 @@ class FW_WP_Option
 	 * @param string|null $specific_multi_key
 	 * @param array|string|int|bool $set_value
 	 */
-	public static function set($option_name, $specific_multi_key = null, $set_value)
+	public static function set($option_name = '', $specific_multi_key = null, $set_value = '')
 	{
 		if ($specific_multi_key === null) { // Replace entire option
 			update_option($option_name, $set_value, false);

--- a/framework/helpers/database.php
+++ b/framework/helpers/database.php
@@ -71,7 +71,7 @@ class FW_Db_Options_Model_Settings extends FW_Db_Options_Model {
 		 * @param null $option_id Specific option id (accepts multikey). null - all options
 		 * @param mixed $value
 		 */
-		function fw_set_db_settings_option( $option_id = null, $value ) {
+		function fw_set_db_settings_option( $option_id = null, $value = '' ) {
 			FW_Db_Options_Model_Settings::_get_instance('settings')->set(null, $option_id, $value);
 		}
 	}
@@ -235,7 +235,7 @@ class FW_Db_Options_Model_Post extends FW_Db_Options_Model {
 		 * @param string|null $option_id Specific option id (accepts multikey). null - all options
 		 * @param $value
 		 */
-		function fw_set_db_post_option( $post_id = null, $option_id = null, $value ) {
+		function fw_set_db_post_option( $post_id = null, $option_id = null, $value = '' ) {
 			FW_Db_Options_Model::_get_instance('post')->set(intval($post_id), $option_id, $value);
 		}
 
@@ -430,7 +430,7 @@ class FW_Db_Options_Model_Term extends FW_Db_Options_Model {
 		 *
 		 * @return null
 		 */
-		function fw_set_db_term_option( $term_id, $taxonomy, $option_id = null, $value ) {
+		function fw_set_db_term_option( $term_id, $taxonomy, $option_id = null, $value = '' ) {
 			if ( ! taxonomy_exists( $taxonomy ) ) {
 				return null;
 			}
@@ -497,7 +497,7 @@ class FW_Db_Options_Model_Extension extends FW_Db_Options_Model {
 		 * @param string|null $option_id
 		 * @param mixed $value
 		 */
-		function fw_set_db_ext_settings_option( $extension_name, $option_id = null, $value ) {
+		function fw_set_db_ext_settings_option( $extension_name, $option_id = null, $value = '' ) {
 			if ( ! fw_ext( $extension_name ) ) {
 				trigger_error( 'Invalid extension: ' . $extension_name, E_USER_WARNING );
 
@@ -585,7 +585,7 @@ class FW_Db_Options_Model_Customizer extends FW_Db_Options_Model {
 		 * @param null $option_id Specific option id (accepts multikey). null - all options
 		 * @param mixed $value
 		 */
-		function fw_set_db_customizer_option( $option_id = null, $value ) {
+		function fw_set_db_customizer_option( $option_id = null, $value = '' ) {
 			FW_Db_Options_Model::_get_instance('customizer')->set(null, $option_id, $value);
 		}
 
@@ -695,7 +695,7 @@ new FW_Db_Options_Model_Customizer();
 	 * @param string|null $multi_key The key of the data you want to set. null - all data
 	 * @param mixed $value
 	 */
-	function fw_set_db_extension_data( $extension_name, $multi_key = null, $value ) {
+	function fw_set_db_extension_data( $extension_name, $multi_key = null, $value = '' ) {
 		if ( ! fw()->extensions->get( $extension_name ) ) {
 			trigger_error( 'Invalid extension: ' . $extension_name, E_USER_WARNING );
 

--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -516,7 +516,7 @@ function fw_stripslashes_deep_keys( $value ) {
 function fw_addslashes_deep_keys( $value ) {
 	static $magic_quotes = null;
 	if ( $magic_quotes === null ) {
-		$magic_quotes = get_magic_quotes_gpc();
+		$magic_quotes = false;
 	}
 
 	if ( is_array( $value ) ) {


### PR DESCRIPTION
get_magic_quotes_gpc() removed for PHP8
Deprecated: Required parameter $value follows optional parameter